### PR TITLE
improvement: adds a small improvement to the station finder tool

### DIFF
--- a/src/lib/Actions.py
+++ b/src/lib/Actions.py
@@ -3283,9 +3283,9 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
                     },
                     "minItems": 1,
                 },
-                "market": {
+                "commodity": {
                     "type": "array",
-                    "description": "Market commodities to buy and sell",
+                    "description": "Commodities to buy or sell at a station. This is not the station name and must map to a commodity name",
                     "items": {
                         "type": "object",
                         "properties": {


### PR DESCRIPTION
This fixes an issue i have seen a lot where the ai gets the station and market mixed up, and ends up searching for a station named "gold"...etc. Changing the field name and description to commodity in the tool has rectified this for me.