### PR TITLE
Feat/add tts instructions support

### DIFF
--- a/docs/30_description.md
+++ b/docs/30_description.md
@@ -46,6 +46,8 @@ The TTS functionality delivers auditory feedback based on the actions and respon
 You can change the STT model's name, endpoint and if required API key in the "AI Geeks Section" of the settings.
 On default, the program will use OpenAI's services to generate the AI's voice, or from the operating system if the local option was chosen.
 
+In addition to this, "Voice tone instructions" are supported for users of openai gpt-4o-mini-tts - allowing you to control how you want the voice to sound.
+
 ### 4. Vision Capabilities
 
 The AI can take screenshots and analyze their content to provide visual confirmations and insights based on the commander's queries. **This feature relies on enabled Function Calling.**

--- a/src/Chat.py
+++ b/src/Chat.py
@@ -36,7 +36,9 @@ class Chat:
         self.config = config # todo: remove
         if self.config["api_key"] == '':
             self.config["api_key"] = '-'
-        
+
+        self.voice_instructions = self.config["tts_prompt"]
+
         self.backstory = self.config["character"].replace("{commander_name}", self.config['commander_name'])
 
         self.enabled_game_events: list[str] = []
@@ -91,7 +93,7 @@ class Chat:
             )
             
         tts_provider = 'none' if self.config["edcopilot_dominant"] else self.config["tts_provider"]
-        self.tts = TTS(openai_client=self.ttsClient, provider=tts_provider, model=self.config["tts_model_name"], voice=self.config["tts_voice"], speed=self.config["tts_speed"], output_device=self.config["output_device_name"])
+        self.tts = TTS(openai_client=self.ttsClient, provider=tts_provider, model=self.config["tts_model_name"], voice=self.config["tts_voice"], voice_instructions=self.config["tts_prompt"], speed=self.config["tts_speed"], output_device=self.config["output_device_name"])
         self.stt = STT(openai_client=self.sttClient, provider=self.config["stt_provider"], input_device_name=self.config["input_device_name"], model=self.config["stt_model_name"], custom_prompt=self.config["stt_custom_prompt"], required_word=self.config["stt_required_word"])
 
         log("debug", "Initializing EDKeys...")

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -3060,7 +3060,7 @@ class PromptGenerator:
                 enhanced_nav_route.append(system_data)
             
             # We need to convert to a dict to add 'Jumps'
-            enhanced_nav_route_dict = {"Systems": enhanced_nav_route, "Jumps": total_systems}
+            enhanced_nav_route_dict = {"Systems": enhanced_nav_route, "Jumps": total_systems - 1}
             
             # Set appropriate title based on whether we're showing all systems or just the first 20
             nav_route_title = "Nav Route"

--- a/src/lib/TTS.py
+++ b/src/lib/TTS.py
@@ -39,11 +39,13 @@ class Mp3Stream(miniaudio.StreamableSource):
 
 @final
 class TTS:
-    def __init__(self, openai_client: Optional[openai.OpenAI] = None, provider: Literal["none", "edge-tts", "openai", "local-ai"]='openai', voice="nova", model='tts-1', speed: Union[str,float]=1, output_device: Optional[str] = None):
+    def __init__(self, openai_client: Optional[openai.OpenAI] = None, provider: Literal['openai', 'edge-tts', 'custom', 'none', 'local-ai-server'] | str ='openai', voice="nova", voice_instructions="", model='tts-1',  speed: Union[str,float]=1, output_device: Optional[str] = None):
         self.openai_client = openai_client
         self.provider = provider
         self.model = model
         self.voice = voice
+        self.voice_instructions = voice_instructions
+
         self.speed = speed
         
         self.p = pyaudio.PyAudio()
@@ -168,6 +170,7 @@ class TTS:
                     input=text,
                     response_format="pcm",
                     # raw samples in 24kHz (16-bit signed, low-endian), without the header.
+                    instructions = self.voice_instructions,
                     speed=float(self.speed)
             ) as response:
                 for chunk in response.iter_bytes(1024):
@@ -204,7 +207,7 @@ class TTS:
 if __name__ == "__main__":
     openai_audio = openai.OpenAI(base_url="http://localhost:8080/v1", api_key='x')
 
-    tts = TTS(openai_audio, provider="openai", model="tts-1", voice="nova", speed=1, output_device="Speakers")
+    tts = TTS(openai_audio, provider="openai", model="tts-1", voice="nova", voice_instructions="", speed=1, output_device="Speakers")
 
 
     text = """The missile knows where it is at all times. It knows this because it knows where it isn't. By subtracting where it is from where it isn't, or where it isn't from where it is (whichever is greater), it obtains a difference, or deviation. The guidance subsystem uses deviations to generate corrective commands to drive the missile from a position where it is to a position where it isn't, and arriving at a position where it wasn't, it now is. Consequently, the position where it is, is now the position that it wasn't, and it follows that the position that it was, is now the position that it isn't.

--- a/test/lib/test_TTS.py
+++ b/test/lib/test_TTS.py
@@ -85,7 +85,21 @@ def test_openai_tts_playback(mock_pyaudio, mock_openai):
         sleep(0.1)
         
     assert mock_pyaudio['stream'].write.call_count == ceil(2*24_000/1024)
-    
+
+
+def test_openai_tts_playback_with_voice_instructions(mock_pyaudio, mock_openai):
+    """Test OpenAI TTS playback"""
+    tts = TTS(mock_openai, provider="openai", model="gpt-4o-mini-tts", voice="nova", voice_instructions="Speak normally...")
+    tts.say("Hello world")
+
+    while not mock_openai.audio.speech.with_streaming_response.create.called:
+        sleep(0.1)
+
+    while not mock_pyaudio['stream'].write.call_count == ceil(2 * 24_000 / 1024):
+        sleep(0.1)
+
+    assert mock_pyaudio['stream'].write.call_count == ceil(2 * 24_000 / 1024)
+
 def test_edge_tts_playback(mock_pyaudio, mock_miniaudio, mock_openai):
     """Test Edge-TTS playback"""
     tts =  TTS(None, provider="edge-tts", model="edge-tts", voice="en-GB-SoniaNeural", speed=1)

--- a/ui/src/app/components/settings-menu/settings-menu.component.html
+++ b/ui/src/app/components/settings-menu/settings-menu.component.html
@@ -257,7 +257,8 @@
 
                                         <!-- TTS Prompt -->
                                         @if (voiceInstructionSupportedModels.includes(config.tts_model_name)) {
-                                        <mat-hint><b>Voice instructions</b><br>Enter a description of how you want your voice to sound.<br>You can include things such as: accent, emotional range, tone, impressions and speed.</mat-hint>
+                                        <mat-hint><b>Voice instructions</b><br>Enter a detailed description of how you want your voice to sound.<br>You can include things such as: accent, emotional range, tone, impressions and speed.<br>
+                                            Warning: This will increase the cost of each query!</mat-hint>
                                         <mat-form-field>
                                             <mat-label>Voice Tone Instructions</mat-label>
                                             <textarea matInput [(ngModel)]="config.tts_prompt"
@@ -851,7 +852,8 @@
                                    (ngModelChange)="onConfigChange({tts_api_key: $event})">
                         </mat-form-field>
                         @if (voiceInstructionSupportedModels.includes(config.tts_model_name)) {
-                        <mat-hint>Voice instructions: Enter a description of how you want your voice to sound. You can include things such as: accent, emotional range, tone, impressions and speed.</mat-hint>
+                        <mat-hint>Voice instructions: Enter a detailed description of how you want your voice to sound. You can include things such as: accent, emotional range, tone, impressions and speed.<br>
+                            Warning: This will increase the cost of each query!</mat-hint>
                         <mat-form-field>
                             <mat-label>Voice Tone Instructions</mat-label>
                             <textarea matInput [(ngModel)]="config.tts_prompt"

--- a/ui/src/app/components/settings-menu/settings-menu.component.html
+++ b/ui/src/app/components/settings-menu/settings-menu.component.html
@@ -246,21 +246,25 @@
                                     </div>
                                     <div class="trait-select">
                                         <!-- Voice speed -->
+                                        @if (!voiceInstructionSupportedModels.includes(config.tts_model_name)) {
                                         <mat-form-field>
                                             <mat-label>Voice Speed</mat-label>
                                             <input matInput [(ngModel)]="config.tts_speed"
                                                    (ngModelChange)="onConfigChange({tts_speed: $event})">
                                             <mat-hint>Speed multiplier (1.0 = normal speed)</mat-hint>
                                         </mat-form-field>
-                                    </div>
-                                    <div class="trait-select">
+                                        }
+
                                         <!-- TTS Prompt -->
+                                        @if (voiceInstructionSupportedModels.includes(config.tts_model_name)) {
+                                        <mat-hint><b>Voice instructions</b><br>Enter a description of how you want your voice to sound.<br>You can include things such as: accent, emotional range, tone, impressions and speed.</mat-hint>
                                         <mat-form-field>
-                                            <mat-label>TTS Prompt</mat-label>
+                                            <mat-label>Voice Tone Instructions</mat-label>
                                             <textarea matInput [(ngModel)]="config.tts_prompt"
                                                     (ngModelChange)="onConfigChange({tts_prompt: $event})"></textarea>
-                                            <mat-hint>Custom instructions for voice style/emotion</mat-hint>
+
                                         </mat-form-field>
+                                        }
                                     </div>
                                 </div>
                             </div>
@@ -834,22 +838,27 @@
                                 <mat-option value="shimmer">Shimmer - Clear, warm voice</mat-option>
                             </mat-select>
                         </mat-form-field>
+                        @if (!voiceInstructionSupportedModels.includes(config.tts_model_name)) {
                         <mat-form-field>
                             <mat-label>TTS Speed</mat-label>
                             <input matInput [(ngModel)]="config.tts_speed"
                                    (ngModelChange)="onConfigChange({tts_speed: $event})">
                         </mat-form-field>
+                        }
                         <mat-form-field>
                             <mat-label>Override TTS API Key</mat-label>
                             <input matInput type="password" [(ngModel)]="config.tts_api_key"
                                    (ngModelChange)="onConfigChange({tts_api_key: $event})">
                         </mat-form-field>
+                        @if (voiceInstructionSupportedModels.includes(config.tts_model_name)) {
+                        <mat-hint>Voice instructions: Enter a description of how you want your voice to sound. You can include things such as: accent, emotional range, tone, impressions and speed.</mat-hint>
                         <mat-form-field>
-                            <mat-label>TTS Prompt</mat-label>
+                            <mat-label>Voice Tone Instructions</mat-label>
                             <textarea matInput [(ngModel)]="config.tts_prompt"
                                    (ngModelChange)="onConfigChange({tts_prompt: $event})"></textarea>
-                            <mat-hint>Custom instructions for the TTS system to control voice style, emotion, etc.</mat-hint>
+
                         </mat-form-field>
+                        }
                     }
                     @if (config.tts_provider === "edge-tts") {
                         <mat-form-field>

--- a/ui/src/app/components/settings-menu/settings-menu.component.ts
+++ b/ui/src/app/components/settings-menu/settings-menu.component.ts
@@ -88,6 +88,7 @@ export class SettingsMenuComponent implements OnInit, OnDestroy {
   expandedSection: string | null = null;
   filteredGameEvents: Record<string, Record<string, boolean>> = {};
   eventSearchQuery: string = "";
+  voiceInstructionSupportedModels: string[] = ['gpt-4o-mini-tts'];
 
   gameEventCategories = GameEventCategories;
   settings: PromptSettings = {


### PR DESCRIPTION
Adds tts instructions support
UI updated so prompt is only  when gpt-4o-mini-tts is given as tts model is given.
Speed is hidden also in this case
list of models that drives this behaviour within a list in the the angular code.