### PR TITLE
Improvement/rework of docking request macro

### DIFF
--- a/src/lib/Actions.py
+++ b/src/lib/Actions.py
@@ -416,9 +416,21 @@ def undock(args, projected_states):
 
     return 'The ship is now undocking'
 
+def docking_key_press_sequence(stop_event):
+    keys.send('UI_Left')
+    keys.send('UI_Right')
+    keys.send("UI_Select",hold = 0.2)
+    for _ in range(6):
+        if stop_event.is_set():
+            break
+        keys.send("CyclePreviousPanel")
+        keys.send('UI_Left')
+        keys.send('UI_Right')
+        keys.send("UI_Select",hold = 0.2)
+
+
 def request_docking(args, projected_states):
     checkStatus(projected_states, {'Supercruise':True})
-    screenreader = ScreenReader()
     setGameWindowActive()
     if projected_states.get('CurrentStatus').get('GuiFocus') in ['NoFocus', 'InternalPanel', 'CommsPanel', 'RolePanel']:
         keys.send('FocusLeftPanel')
@@ -428,33 +440,23 @@ def request_docking(args, projected_states):
     else:
         raise Exception('Docking menu not available in current UI Mode.')
 
-    mode = None
-    for x in range(4):
-        mode = screenreader.detect_lhs_screen_tab()
-        if mode:
-            break
-        keys.send('CycleNextPanel', None, 1)
+    previous_timestamp = (projected_states.get('DockingEvents') or {}).get('RequestDeliveredTimestamp')
 
-    log('debug', 'Docking request screen tab', mode)
-    if not mode:
-        raise Exception('Panel not found')
-    if mode == 'system':
-        keys.send('CycleNextPanel', None, 3)
-    elif mode == 'navigation':
-        keys.send('CycleNextPanel', None, 2)
-    elif mode == 'transactions':
-        keys.send('CycleNextPanel', None, 1)
+    stop_event = threading.Event()
+    t = threading.Thread(target=docking_key_press_sequence, args=(stop_event,))
+    t.start()
 
-    sleep(0.3)
-    keys.send('UI_Left')
-    keys.send('UI_Down')
-    keys.send('UI_Up', hold=1)
-    keys.send('UI_Right')
-    sleep(0.1)
-    keys.send('UI_Select')
+    try:
+        event_manager.wait_for_condition('DockingEvents', lambda s: s.get('RequestDeliveredTimestamp') != previous_timestamp , 10)
+        msg = ""
+    except:
+        msg = "Failed to request docking via menu"
+
+    stop_event.set() # stop the keypress thread
+
     keys.send('UIFocus')
+    return msg
 
-    return f"Docking has been requested"
 
 
 # Ship Launched Fighter Actions
@@ -2755,7 +2757,7 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
          "required": ["power_category"]
      }, manage_power_distribution, 'ship')
 
-    actionManager.registerAction('galaxyMapOpen', "Open galaxy map. Focus on a system or start a navigation route", {
+    actionManager.registerAction('galaxyMapOpen', "Open galaxy map. Optionally, if asked, focus on a system or start a navigation route", {
         "type": "object",
         "properties": {
             "system_name": {
@@ -2780,7 +2782,7 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
             "desired_state": {
                 "type": "string",
                 "enum": ["open", "close"],
-                "description": "Open or close system map",
+                "description": "Desired state for the system map: open or close.",
             },
         },
     }, system_map_open_or_close, 'ship')
@@ -3024,7 +3026,7 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
         "properties": {}
     }, recall_dismiss_ship_buggy, 'buggy')
 
-    actionManager.registerAction('galaxyMapOpenOrCloseBuggy', "Open/close galaxy map. optionally focus on a system or start a navigation route to a system", {
+    actionManager.registerAction('galaxyMapOpenOrCloseBuggy', "Open/close galaxy map. optionally, when asked, focus on a system or start a navigation route to a system", {
         "type": "object",
         "properties": {
             "desired_state": {
@@ -3049,7 +3051,7 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
             "desired_state": {
                 "type": "string",
                 "enum": ["open", "close"],
-                "description": "Open or close system map",
+                "description": "Desired state for the system map: open or close.",
             },
         },
     }, system_map_open_buggy, 'buggy')
@@ -3118,12 +3120,12 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
         "properties": {}
     }, battery_humanoid, 'humanoid')
 
-    actionManager.registerAction('galaxyMapOpenOrCloseHumanoid', "Open or CLose Galaxy Map", {
+    actionManager.registerAction('galaxyMapOpenOrCloseHumanoid', "Open or Close Galaxy Map", {
         "type": "object",
         "properties": {}
     }, galaxy_map_open_humanoid, 'humanoid')
 
-    actionManager.registerAction('systemMapOpenOrCloseHumanoid', "Open or CLose System Map", {
+    actionManager.registerAction('systemMapOpenOrCloseHumanoid', "Open or Close System Map", {
         "type": "object",
         "properties": {}
     }, system_map_open_humanoid, 'humanoid')

--- a/src/lib/Actions.py
+++ b/src/lib/Actions.py
@@ -2757,7 +2757,7 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
          "required": ["power_category"]
      }, manage_power_distribution, 'ship')
 
-    actionManager.registerAction('galaxyMapOpen', "Open galaxy map. Optionally, if asked, focus on a system or start a navigation route", {
+    actionManager.registerAction('galaxyMapOpen', "Open galaxy map. If asked, also focus on a system or start a navigation route", {
         "type": "object",
         "properties": {
             "system_name": {
@@ -3026,7 +3026,7 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
         "properties": {}
     }, recall_dismiss_ship_buggy, 'buggy')
 
-    actionManager.registerAction('galaxyMapOpenOrCloseBuggy', "Open/close galaxy map. optionally, when asked, focus on a system or start a navigation route to a system", {
+    actionManager.registerAction('galaxyMapOpenOrCloseBuggy', "Open galaxy map. If asked, also focus on a system or start a navigation route", {
         "type": "object",
         "properties": {
             "desired_state": {

--- a/src/lib/Assistant.py
+++ b/src/lib/Assistant.py
@@ -43,7 +43,9 @@ class Assistant:
                 self.tts.say(action_input_desc)
             action_result = self.action_manager.runAction(action, projected_states)
             action_results.append(action_result)
-            self.event_manager.add_tool_call([action.model_dump()], [action_result], [action_input_desc] if action_input_desc else None)
+
+            if action_result['content'] != '': # We don't add a response if the return from an action is blank
+                self.event_manager.add_tool_call([action.model_dump()], [action_result], [action_input_desc] if action_input_desc else None)
 
 
     def verify_action(self, user_input: list[str], action: dict[str, Any], prompt: list, tools: list):

--- a/src/lib/EDKeys.py
+++ b/src/lib/EDKeys.py
@@ -75,6 +75,7 @@ class EDKeys:
             'ToggleCargoScoop',
             'ChargeECM',
             'CycleNextPanel',
+            'CyclePreviousPanel',
             'FocusLeftPanel',
             'UI_Up',
             'UI_Down',

--- a/src/lib/Projections.py
+++ b/src/lib/Projections.py
@@ -990,6 +990,25 @@ class ColonisationConstruction(Projection[ColonisationConstructionState]):
             self.state["StarSystemRecall"] = event.content.get('StarSystem', 'Unknown')
 
 
+DockingEventsState = TypedDict('DockingEventsState', {
+    "RequestDeliveredTimestamp": str
+})
+
+@final
+class DockingEvents(Projection[DockingEventsState]):
+    @override
+    def get_default_state(self) -> DockingEventsState:
+        return {
+            "RequestDeliveredTimestamp": ''
+        }
+
+    def process(self, event: Event):
+
+        if isinstance(event, GameEvent) and event.content.get('event') in ['DockingRequested','DockingDenied']:
+            # Provides a reliable timestamp string for condition checking. DockingRequested events are not always sent after a docking request if it's denied
+            self.state['RequestDeliveredTimestamp'] = event.content.get('timestamp','')
+
+
 
 def registerProjections(event_manager: EventManager, system_db: SystemDatabase):
 
@@ -1006,6 +1025,7 @@ def registerProjections(event_manager: EventManager, system_db: SystemDatabase):
     event_manager.register_projection(SuitLoadout())
     event_manager.register_projection(Friends())
     event_manager.register_projection(ColonisationConstruction())
+    event_manager.register_projection(DockingEvents())
 
     # ToDo: SLF, SRV,
     for proj in [


### PR DESCRIPTION
This adds a screenshot free version of making a docking request.

- Adds a DockingEvent projection. This is required because if the request is denied the DockingRequest event doesn't occur in the journal
- Adds a keypress thread loop
- Updated requestion docking action method to wait for the projection condition
- Made small change so we can optionally not have C:N comment on the return of an action.
           - Needed to make this approach viable otherwise we end up with granted happening before we get a tool call return on the request. The user can still get confirmation if they desire by using the DockingRequest behaviour event in the UI - which will always be in order.
- Made some tweaks to the galaxy / system map tool descriptions as I encountered occasional resistance to open or it would focus on a system when I didn't ask.
- CyclePreviousPanel key bind added as the new macro uses this