### PR TITLE
DMigration to pydantic-to-typescript for generating frontend types.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -83,3 +83,4 @@ urllib3==2.2.2
 wrapt==1.16.0
 zipp==3.19.2
 EDMesg @ git+https://github.com/RatherRude/EDMesg.git@e4a387e
+pydantic-to-typescript==2.0.0

--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -9,6 +9,7 @@ import sys
 from openai import OpenAI, APIError
 
 from .Logger import log
+from .shared.SystemTypes import SystemInfo
 
 # List of game events categorized
 game_events = {
@@ -714,14 +715,6 @@ def get_output_device_names() -> list[str]:
 def get_default_output_device_name() -> str:
     devices = get_output_device_names()
     return devices[0] if devices else ""
-
-
-class SystemInfo(TypedDict):
-    os: str
-    input_device_names: list[str]
-    output_device_names: list[str]
-    edcopilot_installed: bool
-
 
 def get_system_info() -> SystemInfo:
     from .EDCoPilot import EDCoPilot

--- a/src/lib/shared/SystemTypes.py
+++ b/src/lib/shared/SystemTypes.py
@@ -1,0 +1,8 @@
+from typing import Literal, TypedDict
+from pydantic import BaseModel
+
+class SystemInfo(BaseModel):
+    os: str
+    input_device_names: list[str]
+    output_device_names: list[str]
+    edcopilot_installed: bool

--- a/src/lib/shared/models.py
+++ b/src/lib/shared/models.py
@@ -1,0 +1,1 @@
+from .SystemTypes import *

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,10 +4,11 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "dev": "tauri dev",
-    "build": "ng build",
-    "watch": "ng build --watch --configuration development",
-    "tauri": "tauri"
+    "generate-types": "pydantic2ts --module ../src/lib/shared/models.py --output src/app/types/models.d.ts",
+    "dev": "npm run generate-types && tauri dev",
+    "build": "npm run generate-types && ng build",
+    "watch": "npm run build --watch --configuration development",
+    "tauri": "npm run generate-types && tauri"
   },
   "private": true,
   "dependencies": {
@@ -35,6 +36,7 @@
     "@tauri-apps/cli": "^2",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.1.0",
+    "json-schema-to-typescript": "^15.0.4",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",

--- a/ui/src/app/components/settings-menu/settings-menu.component.ts
+++ b/ui/src/app/components/settings-menu/settings-menu.component.ts
@@ -11,7 +11,6 @@ import {
   Character,
   Config,
   ConfigService,
-  SystemInfo,
 } from "../../services/config.service";
 import { Subscription } from "rxjs";
 import { MatButtonModule } from "@angular/material/button";
@@ -27,6 +26,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { EdgeTtsVoicesDialogComponent } from '../edge-tts-voices-dialog';
 import { ConfirmationDialogComponent, ConfirmationDialogData } from '../../components/confirmation-dialog/confirmation-dialog.component';
 import { ConfirmationDialogService } from '../../services/confirmation-dialog.service';
+import { SystemInfo } from "../../types/models";
 
 interface PromptSettings {
   // Existing settings

--- a/ui/src/app/services/config.service.ts
+++ b/ui/src/app/services/config.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core";
 import { BehaviorSubject, filter, Observable } from "rxjs";
 import { type BaseMessage, TauriService } from "./tauri.service";
+import { SystemInfo } from "../types/models";
 
 export interface ConfigMessage extends BaseMessage {
     type: "config";
@@ -36,13 +37,6 @@ export interface ModelValidationMessage extends BaseMessage {
 
 export interface StartMessage extends BaseMessage {
     type: "start";
-}
-
-export interface SystemInfo {
-    os: string;
-    input_device_names: string[];
-    output_device_names: string[];
-    edcopilot_installed: boolean;
 }
 
 export interface SystemInfoMessage extends BaseMessage {

--- a/ui/src/app/types/models.d.ts
+++ b/ui/src/app/types/models.d.ts
@@ -1,0 +1,13 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+/* This file was automatically generated from pydantic models by running pydantic2ts.
+/* Do not modify it by hand - just update the pydantic models and then re-run the script
+*/
+
+export interface SystemInfo {
+  os: string;
+  input_device_names: string[];
+  output_device_names: string[];
+  edcopilot_installed: boolean;
+}


### PR DESCRIPTION
So far this is just a proof of concept, to see if it's a feasible idea.  
I've made a simple test-case of unifying the SystemInfo type, since it was easy. Have a look.  
This PR aims to decrease complexity and the risk of mistakes, by unifying types between the typescript frontend and the Python backend.