### PR TITLE
Small startup performance improvement

### DIFF
--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -724,13 +724,12 @@ class SystemInfo(TypedDict):
 
 
 def get_system_info() -> SystemInfo:
-    from .EDCoPilot import EDCoPilot
-    edcopilot: Any = EDCoPilot(False)  # this is only for the GUI, the actual EDCoPilot client is created in the Chat
+    from .EDCoPilot import get_install_path
     return {
         "os": platform.system(),
         "input_device_names": get_input_device_names(),
         "output_device_names": get_output_device_names(),
-        "edcopilot_installed": edcopilot.is_installed(),
+        "edcopilot_installed": get_install_path() is not None,
     }
 
 

--- a/src/lib/EDCoPilot.py
+++ b/src/lib/EDCoPilot.py
@@ -19,7 +19,7 @@ from EDMesg.base import EDMesgWelcomeAction
 @final
 class EDCoPilot:
     def __init__(self, is_enabled: bool, is_edcopilot_dominant: bool=False, enabled_game_events: list[str]=[]):
-        self.install_path = self.get_install_path()
+        self.install_path = get_install_path()
         self.proc_id = self.get_process_id()
         self.is_enabled = is_enabled and self.is_installed()
         self.client = None
@@ -69,18 +69,6 @@ class EDCoPilot:
         self.proc_id = self.get_process_id()
         return self.proc_id is not None
 
-    def get_install_path(self) -> (str | None):
-        """Check the windows registry for COMPUTER / HKEY_CURRENT_USER / SOFTWARE / EDCoPilot"""
-        try:
-            import winreg
-
-            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "SOFTWARE\\EDCoPilot")
-            value, _ = winreg.QueryValueEx(key, "EDCoPilotLib")
-            winreg.CloseKey(key)
-            return value
-        except Exception:
-            return None
-
     def get_process_id(self) -> (int | None):
         """Check if EDCoPilot is running"""
         try:
@@ -116,6 +104,17 @@ class EDCoPilot:
                 )
             )
 
+def get_install_path() -> (str | None):
+    """Check the windows registry for COMPUTER / HKEY_CURRENT_USER / SOFTWARE / EDCoPilot"""
+    try:
+        import winreg
+
+        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "SOFTWARE\\EDCoPilot")
+        value, _ = winreg.QueryValueEx(key, "EDCoPilotLib")
+        winreg.CloseKey(key)
+        return value
+    except Exception:
+        return None
 
 if __name__ == "__main__":
     client = create_covasnext_client()


### PR DESCRIPTION
Just a small performance improvement, by avoiding complete initialization of the `EDCoPilot` class when all we need is the install path.
It shaved a couple of seconds off startup, at least during development.

I moved the `get_install_path()` function out of the ´EDCoPilot` class. so it doesn't have to be initialized.