### PR TITLE
Added guard against long STT phrases.

### DIFF
--- a/src/lib/STT.py
+++ b/src/lib/STT.py
@@ -15,6 +15,7 @@ from pysilero_vad import SileroVoiceActivityDetector
 
 from .Logger import log
 
+MAX_TEXT_LENGTH = 512
 
 @final
 class STTResult:
@@ -215,7 +216,11 @@ class STT:
         if self.required_word and self.required_word.lower() not in text.lower():
             return ''
 
-        # print("transcription received", text)
+        # Truncate overly long transcriptions - prevents hang
+        if len(text) > MAX_TEXT_LENGTH:
+            log('warn', f"STT transcription too long ({len(text)} chars), truncating")
+            text = text[:MAX_TEXT_LENGTH].rstrip() + "..."
+
         return text
     
     def _transcribe_openai_mm(self, audio: bytes) -> str:


### PR DESCRIPTION
Currently when large STT phrases are entered the tool hangs for me and then wont' respond. 

This adds a truncation on the STT at 512 chars, which I've tested and prevents it.