### PR TITLE
Feat/toggle mic key/Push-to-Mute

### DIFF
--- a/src/Chat.py
+++ b/src/Chat.py
@@ -163,6 +163,13 @@ class Chat:
             )
         else:
             self.stt.listen_continuous()
+
+            # Utilize PTT key as mute key instead.            
+            self.controller_manager.register_hotkey(
+                self.config["ptt_key"], 
+                lambda _: _,
+                lambda _: self.stt.pause_continuous_listening(not self.stt.continuous_listening_paused)
+            )
         log('info', "Voice interface ready.")
 
         registerProjections(self.event_manager, self.system_database, self.character.get('idle_timeout_var', 300))

--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -387,6 +387,8 @@ class Config(TypedDict):
     edcopilot: bool
     edcopilot_dominant: bool
     ptt_key: str
+    ptm_key: str
+    ptm_toggle_var: bool
     input_device_name: str
     output_device_name: str
     cn_autostart: bool
@@ -656,6 +658,8 @@ def load_config() -> Config:
         'llm_endpoint': "https://api.openai.com/v1",
         'llm_api_key': "",
         'ptt_key': '',
+        'ptm_key': '',
+        'ptm_toggle_var': False,
         'vision_provider': "none",
         'vision_model_name': "gpt-4.1-mini",
         'vision_endpoint': "https://api.openai.com/v1",
@@ -713,6 +717,21 @@ def assign_ptt(config: Config, controller_manager):
     def on_hotkey_detected(key: str):
         # print(f"Received key: {key}")
         config["ptt_key"] = key
+        semaphore.release()
+
+    semaphore.acquire()
+    controller_manager.listen_hotkey(on_hotkey_detected)
+    semaphore.acquire()
+    print(json.dumps({"type": "config", "config": config}) + '\n')
+    save_config(config)
+    return config
+
+def assign_ptm(config: Config, controller_manager):
+    semaphore = Semaphore(1)
+
+    def on_hotkey_detected(key: str):
+        # print(f"Received key: {key}")
+        config["ptm_key"] = key
         semaphore.release()
 
     semaphore.acquire()

--- a/ui/src/app/components/settings-menu/settings-menu.component.html
+++ b/ui/src/app/components/settings-menu/settings-menu.component.html
@@ -70,14 +70,27 @@
                                 <mat-option value="ptt">Push-to-Talk</mat-option>
                             </mat-select>
                         </mat-form-field>
-                        <mat-form-field (click)="onAssignPTT()">
-                            <mat-label>{{config.ptt_var ? 'Push-to-Talk Key' : 'Toggle Mute Key'}}</mat-label>
-                            <input required matInput [value]="config.ptt_key" readonly>
-                            <button matSuffix mat-icon-button>
-                                <mat-icon>keyboard</mat-icon>
-                            </button>
-                        </mat-form-field>
+                        @if (config.ptt_var) {
+                            <mat-form-field (click)="onAssignPTT()">
+                                <mat-label>Push-to-Talk Key</mat-label>
+                                <input required matInput [value]="config.ptt_key" readonly>
+                                <button matSuffix mat-icon-button>
+                                    <mat-icon>keyboard</mat-icon>
+                                </button>
+                            </mat-form-field>
+                        }
                         @if (!config.ptt_var) {
+                            <mat-form-field (click)="onAssignPTM()">
+                                <mat-label>Push-to-Mute Key</mat-label>
+                                <input required matInput [value]="config.ptm_key" readonly>
+                                <button matSuffix mat-icon-button>
+                                    <mat-icon>keyboard</mat-icon>
+                                </button>
+                            </mat-form-field>
+                            <mat-slide-toggle [(ngModel)]="config.ptm_toggle_var"
+                                                (ngModelChange)="onConfigChange({ptm_toggle_var: $event})">
+                                Toggle Push-to-Mute
+                            </mat-slide-toggle>
                             <mat-slide-toggle [(ngModel)]="config.mute_during_response_var"
                                                 (ngModelChange)="onConfigChange({mute_during_response_var: $event})">
                                 Mute microphone during response

--- a/ui/src/app/components/settings-menu/settings-menu.component.html
+++ b/ui/src/app/components/settings-menu/settings-menu.component.html
@@ -70,15 +70,13 @@
                                 <mat-option value="ptt">Push-to-Talk</mat-option>
                             </mat-select>
                         </mat-form-field>
-                        @if (config.ptt_var) {
-                            <mat-form-field (click)="onAssignPTT()">
-                                <mat-label>Push-to-Talk Key</mat-label>
-                                <input required matInput [value]="config.ptt_key" readonly>
-                                <button matSuffix mat-icon-button>
-                                    <mat-icon>keyboard</mat-icon>
-                                </button>
-                            </mat-form-field>
-                        }
+                        <mat-form-field (click)="onAssignPTT()">
+                            <mat-label>{{config.ptt_var ? 'Push-to-Talk Key' : 'Toggle Mute Key'}}</mat-label>
+                            <input required matInput [value]="config.ptt_key" readonly>
+                            <button matSuffix mat-icon-button>
+                                <mat-icon>keyboard</mat-icon>
+                            </button>
+                        </mat-form-field>
                         @if (!config.ptt_var) {
                             <mat-slide-toggle [(ngModel)]="config.mute_during_response_var"
                                                 (ngModelChange)="onConfigChange({mute_during_response_var: $event})">

--- a/ui/src/app/components/settings-menu/settings-menu.component.ts
+++ b/ui/src/app/components/settings-menu/settings-menu.component.ts
@@ -463,6 +463,10 @@ export class SettingsMenuComponent implements OnInit, OnDestroy {
     await this.configService.assignPTT();
   }
 
+  async onAssignPTM() {
+    await this.configService.assignPTM();
+  }
+
   private categorizeEvents(
     events: Record<string, boolean>,
   ): Record<string, Record<string, boolean>> {

--- a/ui/src/app/services/config.service.ts
+++ b/ui/src/app/services/config.service.ts
@@ -124,6 +124,8 @@ export interface Config {
     edcopilot: boolean;
     edcopilot_dominant: boolean;
     ptt_key: string;
+    ptm_key: string;
+    ptm_toggle_var: boolean;
     input_device_name: string;
     output_device_name: string;
     cn_autostart: boolean;
@@ -278,6 +280,14 @@ export class ConfigService {
     public async assignPTT(): Promise<void> {
         const message = {
             type: "assign_ptt",
+            timestamp: new Date().toISOString(),
+        };
+        await this.tauriService.send_message(message);
+    }
+
+    public async assignPTM(): Promise<void> {
+        const message = {
+            type: "assign_ptm",
             timestamp: new Date().toISOString(),
         };
         await this.tauriService.send_message(message);


### PR DESCRIPTION
Introduces a new keybind for Push-To-Mute, along with a toggle switch. When enabled, the switch allows toggling the microphone on and off.  
When disabled, the keybind functions as an inverted Push-To-Talk (i.e., the mic is muted only while the key is held).

This is pretty useful when running C:N while using voice chat.