### PR TITLE
Fix/huge prompt on market event

### DIFF
--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -2161,6 +2161,9 @@ class PromptGenerator:
             # we know it's a station as we only trigger undocking event if we are inside a station
             return f"{self.commander_name}'s ship has initiated automated docking computer, we are leaving the station"
 
+        if event_name == "Market":
+            return None
+
         if event_name == "DockingComputerDeactivated":
             return f"{self.commander_name}'s ship has deactivated the docking computer"
 

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -2161,11 +2161,11 @@ class PromptGenerator:
             # we know it's a station as we only trigger undocking event if we are inside a station
             return f"{self.commander_name}'s ship has initiated automated docking computer, we are leaving the station"
 
-        if event_name == "Market":
-            return None
-
         if event_name == "DockingComputerDeactivated":
             return f"{self.commander_name}'s ship has deactivated the docking computer"
+
+        if event_name == "Market":
+            return None
 
         log('debug', f'fallback for event', event_name, content)
 


### PR DESCRIPTION
I spotted this as I noticed a large regression in llm response time and wondered what was going on.... For example i was requesting docking and it wasn't telling me it had been granted till i was already inside the station.....

turned out that because the code wasn't catching the market event it was being picked up by the yaml dump in the event template - which was of the entire Market.json file.... 

I went back and checked - in terms of numbers we were adding - my prompt was 122,768 characters long at one point.

Added a return None on the "Market" event.