### PR TITLE
Plugin updates and installation v2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,13 @@
     "GTK_PATH": null,
     "GIO_MODULE_DIR": null,
   },
-  "rust-analyzer.linkedProjects": ["ui/src-tauri/Cargo.toml"]
+  "rust-analyzer.linkedProjects": [
+    "ui/src-tauri/Cargo.toml"
+  ],
+  "files.exclude": {
+    "**/*.rpyc": true,
+    "**/*.rpa": true,
+    "**/*.rpymc": true,
+    "**/cache/": true
+  }
 }

--- a/docs/plugins/plugin_index.json
+++ b/docs/plugins/plugin_index.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "COVAS:NEXT Media Player Plugin",
+        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-Media-Player-Plugin/main/manifest.json"
+    },
+    {
+        "name": "COVAS:NEXT Sticky Notes Plugin",
+        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-Sticky-Notes-Plugin/main/manifest.json"
+    }
+]

--- a/docs/plugins/plugin_index.json
+++ b/docs/plugins/plugin_index.json
@@ -1,10 +1,10 @@
 [
     {
         "name": "COVAS:NEXT Media Player Plugin",
-        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-Media-Player-Plugin/main/manifest.json"
+        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-Media-Player-Plugin/refs/heads/master/manifest.json"
     },
     {
         "name": "COVAS:NEXT Sticky Notes Plugin",
-        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-Sticky-Notes-Plugin/main/manifest.json"
+        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-Sticky-Notes-Plugin/refs/heads/master/manifest.json"
     }
 ]

--- a/docs/plugins/plugin_index.json
+++ b/docs/plugins/plugin_index.json
@@ -5,6 +5,6 @@
     },
     {
         "name": "COVAS:NEXT Sticky Notes Plugin",
-        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-Sticky-Notes-Plugin/refs/heads/master/manifest.json"
+        "latest_manifest_url": "https://raw.githubusercontent.com/MaverickMartyn/COVAS-NEXT-StickyNotes-Plugin/refs/heads/master/manifest.json"
     }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,3 +84,4 @@ wrapt==1.16.0
 zipp==3.19.2
 EDMesg @ git+https://github.com/RatherRude/EDMesg.git@e4a387e
 python-json-logger==3.3.0
+semantic-version==2.10.0

--- a/src/Chat.py
+++ b/src/Chat.py
@@ -341,6 +341,7 @@ if __name__ == "__main__":
         log('debug', "Loading plugins...")
         plugin_manager = PluginManager()
         plugin_manager.load_plugins()
+        plugin_manager.check_for_plugin_updates()
         log('debug', "Registering plugin settings for the UI...")
         plugin_manager.register_settings()
         # Wait for start signal on stdin

--- a/src/Chat.py
+++ b/src/Chat.py
@@ -380,6 +380,10 @@ if __name__ == "__main__":
                 if data.get("type") == "clear_history":
                     EventManager.clear_history()
                     #ActionManager.clear_action_cache()
+                if data.get("type") == "update_plugins":
+                    plugin_manager.update_plugins()
+                if data.get("type") == "change_installed_plugins":
+                    plugin_manager.change_installed_plugins(data["plugins"])
                 
             except json.JSONDecodeError:
                 continue

--- a/src/lib/Actions.py
+++ b/src/lib/Actions.py
@@ -5370,6 +5370,34 @@ def register_actions(actionManager: ActionManager, eventManager: EventManager, l
             "required": ["query"]
         }, get_visuals, 'global')
 
+    def set_damage_level_for_testing(obj, projected_states) -> str:
+        """
+        Set the simulated damage level used for voice effects.
+        This is only for testing purposes and should not be used in production.
+        """
+        if 'level' not in obj or not isinstance(obj['level'], int):
+            return "ERROR: Invalid damage level. Please provide an integer between 0 and 100."
+
+        level = obj['level']
+        if level < 0 or level > 100:
+            return "ERROR: Damage level must be between 0 and 100."
+
+        # Set the damage level in the global state
+        projected_states['global']['damage_level'] = level
+        return f"Damage level set to {level} for testing purposes."
+
+    actionManager.registerAction('setDamageLevelForTesting', "Set the simulated damage level used for voice effects", {
+        "type": "object",
+        "properties": {
+            "level": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "The damage level to set for testing purposes. 0 = no damage, 100 = maximum damage."
+            }
+        },
+        "required": ["level"]
+    }, set_damage_level_for_testing, 'global')
 
 def format_commodity_name(name: str) -> str:
     """

--- a/src/lib/PluginHelper.py
+++ b/src/lib/PluginHelper.py
@@ -14,6 +14,14 @@ from .Event import Event
 from .PromptGenerator import PromptGenerator
 from .Assistant import Assistant
 
+class PluginSource(object):
+    type: str = ""
+    repo: str = ""
+    asset_name: str = ""
+
+    def __init__(self, j: str) -> None:
+        self.__dict__.update(cast(dict[str, str], json.loads(j)))
+
 class PluginManifest(object):
     guid: str = ""
     name: str = ""
@@ -22,6 +30,7 @@ class PluginManifest(object):
     repository: str = ""
     description: str = ""
     entrypoint: str = ""
+    source: PluginSource | None = None
 
     def __init__(self, j: str) -> None:
         self.__dict__.update(cast(dict[str, str], json.loads(j)))

--- a/src/lib/PluginHelper.py
+++ b/src/lib/PluginHelper.py
@@ -1,3 +1,5 @@
+from abc import ABC
+from dataclasses import dataclass
 import json
 import os
 from typing import Any, Callable, TypedDict, cast
@@ -14,14 +16,25 @@ from .Event import Event
 from .PromptGenerator import PromptGenerator
 from .Assistant import Assistant
 
-class PluginSource(object):
-    type: str = ""
+@dataclass
+class GitHubPluginSource(object):
+    type: str = "github"
     repo: str = ""
     asset_name: str = ""
 
     def __init__(self, j: str) -> None:
         self.__dict__.update(cast(dict[str, str], json.loads(j)))
 
+@dataclass
+class UrlPluginSource(object):
+    type: str = "url"
+    download_url: str = ""
+    latest_manifest_url: str = ""
+
+    def __init__(self, j: str) -> None:
+        self.__dict__.update(cast(dict[str, str], json.loads(j)))
+
+@dataclass
 class PluginManifest(object):
     guid: str = ""
     name: str = ""
@@ -30,7 +43,7 @@ class PluginManifest(object):
     repository: str = ""
     description: str = ""
     entrypoint: str = ""
-    source: PluginSource | None = None
+    source: GitHubPluginSource | UrlPluginSource | None = None
 
     def __init__(self, j: str) -> None:
         self.__dict__.update(cast(dict[str, str], json.loads(j)))

--- a/src/lib/PluginHelper.py
+++ b/src/lib/PluginHelper.py
@@ -2,7 +2,7 @@ from abc import ABC
 from dataclasses import dataclass
 import json
 import os
-from typing import Any, Callable, TypedDict, cast
+from typing import Any, Callable, Literal, TypedDict, cast
 import openai
 from openai.types.chat import ChatCompletionMessageParam
 from requests import auth
@@ -16,37 +16,25 @@ from .Event import Event
 from .PromptGenerator import PromptGenerator
 from .Assistant import Assistant
 
-@dataclass
-class GitHubPluginSource(object):
-    type: str = "github"
-    repo: str = ""
-    asset_name: str = ""
+class GitHubPluginSource(TypedDict):
+    type: Literal["github"]
+    repo: str
+    asset_name: str
 
-    def __init__(self, j: str) -> None:
-        self.__dict__.update(cast(dict[str, str], json.loads(j)))
+class UrlPluginSource(TypedDict):
+    type: Literal["url"]
+    download_url: str
+    latest_manifest_url: str
 
-@dataclass
-class UrlPluginSource(object):
-    type: str = "url"
-    download_url: str = ""
-    latest_manifest_url: str = ""
-
-    def __init__(self, j: str) -> None:
-        self.__dict__.update(cast(dict[str, str], json.loads(j)))
-
-@dataclass
-class PluginManifest(object):
-    guid: str = ""
-    name: str = ""
-    author: str = ""
-    version: str = ""
-    repository: str = ""
-    description: str = ""
-    entrypoint: str = ""
-    source: GitHubPluginSource | UrlPluginSource | None = None
-
-    def __init__(self, j: str) -> None:
-        self.__dict__.update(cast(dict[str, str], json.loads(j)))
+class PluginManifest(TypedDict):
+    guid: str
+    name: str
+    author: str
+    version: str
+    repository: str
+    description: str
+    entrypoint: str
+    source: GitHubPluginSource | UrlPluginSource | None
 
 class PluginHelper():
     """Contains all built-inservices and managers that can be used by plugins"""

--- a/src/lib/PluginManager.py
+++ b/src/lib/PluginManager.py
@@ -30,7 +30,7 @@ class PluginManager:
     def __init__(self):
         self.plugin_list: dict[str, PluginBase] = {}
         self.plugin_settings_configs: list[PluginSettings] = []
-        self.discovered_manifests: dict[PluginManifest, str] = {}
+        self.discovered_manifests: dict[str, PluginManifest] = {}
         self.PLUGIN_FOLDER: str = "plugins"
         self.PLUGIN_DL_FOLDER: str = "plugin_downloads"
         self.PLUGIN_DEPENDENCIES_FOLDER: str = "deps"
@@ -88,26 +88,26 @@ class PluginManager:
                     # Load manifest.json
                     with open(os.path.join(subfolder_path, "manifest.json"), "r") as f:
                         json_str = f.read()
-                        manifest = PluginManifest(json_str)
+                        manifest: PluginManifest = json.loads(json_str)
                     
                     # Add manifest to discovered_manifests array
-                    self.discovered_manifests.update({manifest: subfolder_path})
+                    self.discovered_manifests[subfolder_path] = manifest
 
-                    log('debug', f"Loaded manifest for {manifest.name}")
-                    log('debug', f"Entry point: {manifest.entrypoint}")
+                    log('debug', f"Loaded manifest for {manifest["name"]}")
+                    log('debug', f"Entry point: {manifest["entrypoint"]}")
 
                     # Check if the entrypoint is a .py file
-                    if not manifest.entrypoint.endswith(".py"):
+                    if not manifest["entrypoint"].endswith(".py"):
                         log('error', f"Plugin entrypoint {file} is not a .py file")
                         continue
                     
                     # Check if entrypoint file exists
-                    entrypoint_path = os.path.join(subfolder_path, manifest.entrypoint)
+                    entrypoint_path = os.path.join(subfolder_path, manifest["entrypoint"])
                     if not os.path.exists(entrypoint_path):
                         log('error', f"Entrypoint file {entrypoint_path} does not exist")
                         continue
 
-                    module_name = f"{manifest.guid}.{manifest.entrypoint[:-3]}"
+                    module_name = f"{manifest["guid"]}.{manifest["entrypoint"][:-3]}"
                     module = self.load_plugin_module(manifest, entrypoint_path)
                     self.plugin_list[module_name] = module
             except Exception as e:
@@ -116,7 +116,7 @@ class PluginManager:
         # Notify frontend about the discovered plugin manifests.
         print(json.dumps({
             "type": "installed_plugin_list",
-            "plugins": list([asdict(obj) for obj in self.discovered_manifests.keys()]),
+            "plugins": list(self.discovered_manifests.values()),
         }) + '\n', flush=True)
 
         return self
@@ -132,71 +132,71 @@ class PluginManager:
         for key in self.plugin_list.keys():
             module = self.plugin_list[key]
 
-            if module.plugin_manifest.source is None:
-                log('debug', f"Plugin {module.plugin_manifest.name} does not have a source defined in its manifest. Skipping update check.")
+            if module.plugin_manifest["source"] is None:
+                log('debug', f"Plugin {module.plugin_manifest["name"]} does not have a source defined in its manifest. Skipping update check.")
                 continue
 
-            if module.plugin_manifest.source.type == "github" and isinstance(module.plugin_manifest.source, GitHubPluginSource):
-                log('debug', f"Checking for updates for plugin {module.plugin_manifest.name} from {module.plugin_manifest.source.repo}")
+            if module.plugin_manifest["source"]["type"] == "github":
+                log('debug', f"Checking for updates for plugin {module.plugin_manifest["name"]} from {module.plugin_manifest["source"]["repo"]}")
                 try:
                     # Get the latest release information from GitHub
                     response = requests.get(
-                        url=f"https://api.github.com/repos/{module.plugin_manifest.source.repo}/releases/latest"
+                        url=f"https://api.github.com/repos/{module.plugin_manifest["source"]["repo"]}/releases/latest"
                     )
                     if response.status_code == 200:
                         release_info = cast(dict[str, Any], response.json())
                         latest_version = cast(str, release_info.get("tag_name", "unknown"))
-                        log('info', f"Plugin {module.plugin_manifest.name}'s latest version is {latest_version}")
+                        log('info', f"Plugin {module.plugin_manifest["name"]}'s latest version is {latest_version}")
                         
                         # Compare with the current version, using SemVer
                         if not hasattr(module.plugin_manifest, 'version'):
-                            log('error', f"Plugin {module.plugin_manifest.name} does not have a version defined in its manifest.")
+                            log('error', f"Plugin {module.plugin_manifest["name"]} does not have a version defined in its manifest.")
                             continue
-                        current_version = Version(module.plugin_manifest.version)
+                        current_version = Version(module.plugin_manifest["version"])
                         latest_version = Version(latest_version.lstrip('v'))  # Remove 'v'
                         log('debug', f"Current version: {current_version}, Latest version: {latest_version}")
                         if latest_version > current_version:
-                            log('info', f"Plugin {module.plugin_manifest.name} has an update available: {latest_version} (current: {current_version})")
+                            log('info', f"Plugin {module.plugin_manifest["name"]} has an update available: {latest_version} (current: {current_version})")
                             available_updates.append({
-                                "plugin_name": module.plugin_manifest.name,
+                                "plugin_name": module.plugin_manifest["name"],
                                 "current_version": str(current_version),
                                 "latest_version": str(latest_version),
-                                "repo": module.plugin_manifest.source.repo,
+                                "repo": module.plugin_manifest["source"]["repo"],
                                 'release_url': release_info.get('url', '')
                             })
                     else:
-                        log('error', f"Failed to check for updates for {module.plugin_manifest.name}: {response.text}")
+                        log('error', f"Failed to check for updates for {module.plugin_manifest["name"]}: {response.text}")
                 except Exception as e:
-                    log('error', f"Error checking for updates for {module.plugin_manifest.name}: {e}")
-            elif module.plugin_manifest.source.type == "url" and isinstance(module.plugin_manifest.source, UrlPluginSource):
-                log('debug', f"Plugin {module.plugin_manifest.name} has a URL source.")
+                    log('error', f"Error checking for updates for {module.plugin_manifest["name"]}: {e}")
+            elif module.plugin_manifest["source"]["type"] == "url":
+                log('debug', f"Plugin {module.plugin_manifest["name"]} has a URL source.")
 
                 # Get latest manifest from url source, then compare versions with current manifest
                 try:
-                    response = requests.get(module.plugin_manifest.source.latest_manifest_url)
+                    response = requests.get(module.plugin_manifest["source"]["latest_manifest_url"])
                     if response.status_code == 200:
-                        latest_manifest = PluginManifest(response.text)
-                        log('info', f"Plugin {module.plugin_manifest.name}'s latest version is {latest_manifest.version}")
+                        latest_manifest: PluginManifest = json.loads(response.text)
+                        log('info', f"Plugin {module.plugin_manifest["name"]}'s latest version is {latest_manifest["version"]}")
                         
                         # Compare with the current version, using SemVer
                         if not hasattr(module.plugin_manifest, 'version'):
-                            log('error', f"Plugin {module.plugin_manifest.name} does not have a version defined in its manifest.")
+                            log('error', f"Plugin {module.plugin_manifest["name"]} does not have a version defined in its manifest.")
                             continue
-                        current_version = Version(module.plugin_manifest.version)
-                        latest_version = Version(latest_manifest.version.lstrip('v'))
+                        current_version = Version(module.plugin_manifest["version"])
+                        latest_version = Version(latest_manifest["version"].lstrip('v'))
 
                         log('debug', f"Current version: {current_version}, Latest version: {latest_version}")
                         if latest_version > current_version:
-                            log('info', f"Plugin {module.plugin_manifest.name} has an update available: {latest_version} (current: {current_version})")
+                            log('info', f"Plugin {module.plugin_manifest["name"]} has an update available: {latest_version} (current: {current_version})")
                             available_updates.append({
-                                "plugin_name": module.plugin_manifest.name,
+                                "plugin_name": module.plugin_manifest["name"],
                                 "current_version": str(current_version),
                                 "latest_version": str(latest_version),
                                 "repo": None,
-                                'release_url': latest_manifest.repository
+                                'release_url': latest_manifest["repository"]
                             })
                 except Exception as e:
-                    log('error', f"Error checking for updates for {module.plugin_manifest.name}: {e}")
+                    log('error', f"Error checking for updates for {module.plugin_manifest["name"]}: {e}")
         log('info', f"Found {len(available_updates)} plugins with available updates.")
 
         # Notify frontend about the updates
@@ -212,32 +212,32 @@ class PluginManager:
             import shutil
             shutil.rmtree(path, ignore_errors=True)
 
-    def _download_and_extract_plugin_from_github(self, manifest: PluginManifest, release_info: dict, latest_version: str) -> str:
+    def _download_and_extract_plugin_from_github(self, manifest: PluginManifest, release_info: dict, latest_version: str) -> tuple[str, PluginManifest]:
         """Download and extract a plugin from GitHub release assets. Returns the extract path."""
 
-        if not isinstance(manifest.source, GitHubPluginSource):
-            log('debug', f"Plugin {manifest.name} does not have a valid GitHub source defined in its manifest.")
-            raise Exception(f"Plugin {manifest.name} does not have a valid GitHub source defined in its manifest.")
+        if manifest["source"] != "github" or "repo" not in manifest["source"]:
+            log('debug', f"Plugin {manifest["name"]} does not have a valid GitHub source defined in its manifest.")
+            raise Exception(f"Plugin {manifest["name"]} does not have a valid GitHub source defined in its manifest.")
 
         # Download the release asset
         asset = release_info['assets'][0]
         asset_response = requests.get(
-            url=f"https://api.github.com/repos/{manifest.source.repo}/releases/assets/{asset['id']}",
+            url=f"https://api.github.com/repos/{manifest["source"]["repo"]}/releases/assets/{asset['id']}",
             headers={"Accept": "application/octet-stream"}
         )
         if asset_response.status_code != 200:
             raise Exception(f"Failed to download asset: {asset_response.text}")
 
         # Save the zip file
-        zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{manifest.name}-{latest_version}.zip"))
+        zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{manifest["name"]}-{latest_version}.zip"))
         os.makedirs(self.PLUGIN_DL_FOLDER, exist_ok=True)
         with open(zip_file_path, 'wb') as zip_file:
             zip_file.write(asset_response.content)
-        log('info', f"Downloaded plugin {manifest.name} to {zip_file_path}")
+        log('info', f"Downloaded plugin {manifest["name"]} to {zip_file_path}")
 
         # Create valid name for new folder
         import re
-        new_plugin_folder_name = re.sub(r'[<>:"/\\|?*\x00-\x1F]', "", manifest.name)
+        new_plugin_folder_name = re.sub(r'[<>:"/\\|?*\x00-\x1F]', "", manifest["name"])
         new_plugin_folder_name = new_plugin_folder_name.strip().rstrip(". ")
         extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, new_plugin_folder_name))
 
@@ -249,85 +249,108 @@ class PluginManager:
         import zipfile
         with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
             zip_ref.extractall(extract_path)
-        log('info', f"Extracted plugin {manifest.name} to {self.PLUGIN_FOLDER}")
+        log('info', f"Extracted plugin {manifest["name"]} to {self.PLUGIN_FOLDER}")
 
-        return extract_path
+        # Read new manifest.json
+        manifest_path = os.path.join(extract_path, "manifest.json")
+        if not os.path.exists(manifest_path):
+            log('error', f"Manifest file {manifest_path} does not exist after extraction.")
+            raise FileNotFoundError(f"Manifest file {manifest_path} does not exist after extraction.")
+        with open(manifest_path, "r") as f:
+            json_str = f.read()
+            manifest: PluginManifest = json.loads(json_str)
+        log('debug', f"Loaded manifest for {manifest["name"]} from extracted folder.")
+
+        return (extract_path, manifest)
 
     def update_plugins(self):
         """
         Download and install updates for plugins that have an update available.
         """
-        for plugin_manifest in self.discovered_manifests.keys():
-            old_path = self.discovered_manifests[plugin_manifest]
+        for old_path in self.discovered_manifests.keys():
+            plugin_manifest = self.discovered_manifests[old_path]
 
-            if plugin_manifest.source is None:
-                log('debug', f"Plugin {plugin_manifest.name} does not have a source defined in its manifest. Skipping update check.")
+            if plugin_manifest["source"] is None:
+                log('debug', f"Plugin {plugin_manifest["name"]} does not have a source defined in its manifest. Skipping update check.")
                 continue
 
-            if plugin_manifest.source.type == "github" and isinstance(plugin_manifest.source, GitHubPluginSource):
-                log('debug', f"Checking for updates for plugin {plugin_manifest.name} from {plugin_manifest.source.repo}")
+            if plugin_manifest["source"]["type"] == "github":
+                log('debug', f"Checking for updates for plugin {plugin_manifest["name"]} from {plugin_manifest["source"]["repo"]}")
                 try:
                     response = requests.get(
-                        url=f"https://api.github.com/repos/{plugin_manifest.source.repo}/releases/latest"
+                        url=f"https://api.github.com/repos/{plugin_manifest["source"]["repo"]}/releases/latest"
                     )
                     if response.status_code == 200:
                         release_info = cast(dict[str, Any], response.json())
                         latest_version = cast(str, release_info.get("tag_name", "unknown"))
-                        log('info', f"Plugin {plugin_manifest.name}'s latest version is {latest_version}")
+                        log('info', f"Plugin {plugin_manifest["name"]}'s latest version is {latest_version}")
 
                         if not hasattr(plugin_manifest, 'version'):
-                            log('error', f"Plugin {plugin_manifest.name} does not have a version defined in its manifest.")
+                            log('error', f"Plugin {plugin_manifest["name"]} does not have a version defined in its manifest.")
                             continue
-                        current_version = Version(plugin_manifest.version)
+                        current_version = Version(plugin_manifest["version"])
                         latest_version_semver = Version(latest_version.lstrip('v'))
                         log('debug', f"Current version: {current_version}, Latest version: {latest_version_semver}")
                         if latest_version_semver > current_version:
-                            log('info', f"Installing update for plugin {plugin_manifest.name}. Updating from {current_version} to {latest_version_semver}")
+                            log('info', f"Installing update for plugin {plugin_manifest["name"]}. Updating from {current_version} to {latest_version_semver}")
                             self._remove_plugin_folder(old_path)
-                            self.discovered_manifests[plugin_manifest] = self._download_and_extract_plugin_from_github(plugin_manifest, release_info, latest_version)
+                            # Remove manifest from discovered_manifests
+                            del self.discovered_manifests[old_path]
+                            new_plugin  = self._download_and_extract_plugin_from_github(plugin_manifest, release_info, latest_version)
+                            self.discovered_manifests[new_plugin[0]] = new_plugin[1]
                     else:
-                        log('error', f"Failed to check for updates for {plugin_manifest.name}: {response.text}")
+                        log('error', f"Failed to check for updates for {plugin_manifest["name"]}: {response.text}")
                 except Exception as e:
-                    log('error', f"Error checking for updates for {plugin_manifest.name}: {e}")
-            elif plugin_manifest.source.type == "url" and isinstance(plugin_manifest.source, UrlPluginSource):
-                log('debug', f"Plugin {plugin_manifest.name} has a URL source.")
+                    log('error', f"Error checking for updates for {plugin_manifest["name"]}: {e}")
+            elif plugin_manifest["source"]["type"] == "url":
+                log('debug', f"Plugin {plugin_manifest["name"]} has a URL source.")
 
                 # Get latest manifest from url source, then compare versions with current manifest
                 try:
-                    response = requests.get(plugin_manifest.source.latest_manifest_url)
+                    response = requests.get(plugin_manifest["source"]["latest_manifest_url"])
                     if response.status_code == 200:
-                        latest_manifest = PluginManifest(response.text)
-                        log('info', f"Plugin {plugin_manifest.name}'s latest version is {latest_manifest.version}")
+                        latest_manifest: PluginManifest = json.loads(response.text)
+                        log('info', f"Plugin {plugin_manifest["name"]}'s latest version is {latest_manifest["version"]}")
 
                         if not hasattr(plugin_manifest, 'version'):
-                            log('error', f"Plugin {plugin_manifest.name} does not have a version defined in its manifest.")
+                            log('error', f"Plugin {plugin_manifest["name"]} does not have a version defined in its manifest.")
                             continue
-                        current_version = Version(plugin_manifest.version)
-                        latest_version = Version(latest_manifest.version.lstrip('v'))
+                        current_version = Version(plugin_manifest["version"])
+                        latest_version = Version(latest_manifest["version"].lstrip('v'))
 
                         log('debug', f"Current version: {current_version}, Latest version: {latest_version}")
                         if latest_version > current_version:
-                            log('info', f"Installing update for plugin {plugin_manifest.name}. Updating from {current_version} to {latest_version}")
+                            log('info', f"Installing update for plugin {plugin_manifest["name"]}. Updating from {current_version} to {latest_version}")
                             self._remove_plugin_folder(old_path)
-                            extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, plugin_manifest.guid))
+                            extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, plugin_manifest["guid"]))
                             os.makedirs(extract_path, exist_ok=True)
                             
                             # Download the plugin zip file
-                            zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{plugin_manifest.name}-{latest_version}.zip"))
+                            zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{plugin_manifest["name"]}-{latest_version}.zip"))
                             os.makedirs(self.PLUGIN_DL_FOLDER, exist_ok=True)
                             with open(zip_file_path, 'wb') as zip_file:
-                                zip_file.write(requests.get(plugin_manifest.source.download_url).content)
-                            log('info', f"Downloaded plugin {plugin_manifest.name} to {zip_file_path}")
+                                zip_file.write(requests.get(plugin_manifest["source"]["download_url"]).content)
+                            log('info', f"Downloaded plugin {plugin_manifest["name"]} to {zip_file_path}")
                             # Extract the zip file
                             import zipfile
                             with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
                                 zip_ref.extractall(extract_path)
-                            log('info', f"Extracted plugin {plugin_manifest.name} to {self.PLUGIN_FOLDER}")
+                            log('info', f"Extracted plugin {plugin_manifest["name"]} to {self.PLUGIN_FOLDER}")
+
+                            # Read new manifest.json
+                            manifest_path = os.path.join(extract_path, "manifest.json")
+                            if not os.path.exists(manifest_path):
+                                log('error', f"Manifest file {manifest_path} does not exist after extraction.")
+                                raise FileNotFoundError(f"Manifest file {manifest_path} does not exist after extraction.")
+                            with open(manifest_path, "r") as f:
+                                json_str = f.read()
+                                new_manifest: PluginManifest = json.loads(json_str)
+                            log('debug', f"Loaded manifest for {new_manifest["name"]} from extracted folder.")
                             
                             # Update the discovered manifests
-                            self.discovered_manifests[plugin_manifest] = extract_path
+                            self.discovered_manifests[extract_path] = new_manifest
                 except Exception as e:
-                    log('error', f"Error checking for updates for {plugin_manifest.name}: {e}")
+                    log('error', f"Error checking for updates for {plugin_manifest["name"]}: {e}")
 
         print(json.dumps({"type": "plugins_changed", "message": "Plugins have been updated. Please restart the application."}) + '\n', flush=True)
 
@@ -339,111 +362,121 @@ class PluginManager:
         log('info', f"Changing installed plugins to {len(new_plugin_list)} plugins.")
 
         # Remove discovered plugins not in the new list, by guid
-        for manifest in self.discovered_manifests.keys():
-            old_path = self.discovered_manifests[manifest]
-            if manifest.guid not in [p.guid for p in new_plugin_list]:
-                log('debug', f"Uninstalling plugin {manifest.name}.")
+        for old_path in self.discovered_manifests.keys():
+            manifest = self.discovered_manifests[old_path]
+            if manifest["guid"] not in [p["guid"] for p in new_plugin_list]:
+                log('debug', f"Uninstalling plugin {manifest["name"]}.")
                 self._remove_plugin_folder(old_path)
-                del self.discovered_manifests[manifest]
+                del self.discovered_manifests[old_path]
 
         # Download and install new plugins
         for manifest in new_plugin_list:
-            if manifest.guid not in [m.guid for m in self.discovered_manifests.keys()]:
-                log('debug', f"Downloading new plugin {manifest.name}.")
+            if manifest["guid"] not in [m["guid"] for m in self.discovered_manifests.values()]:
+                log('debug', f"Downloading new plugin {manifest["name"]}.")
                 
-                if manifest.source is None:
-                    log('debug', f"Plugin {manifest.name} does not have a source defined in its manifest. Skipping update check.")
+                if manifest["source"] is None:
+                    log('debug', f"Plugin {manifest["name"]} does not have a source defined in its manifest. Skipping update check.")
                     continue
 
-                if manifest.source.type == "github" and isinstance(manifest.source, GitHubPluginSource):
+                if manifest["source"]["type"] == "github":
                     try:
                         response = requests.get(
-                            url=f"https://api.github.com/repos/{manifest.source.repo}/releases/latest"
+                            url=f"https://api.github.com/repos/{manifest["source"]["repo"]}/releases/latest"
                         )
                         if response.status_code == 200:
                             release_info = cast(dict[str, Any], response.json())
                             latest_version = cast(str, release_info.get("tag_name", "unknown"))
-                            log('info', f"Plugin {manifest.name}'s latest version is {latest_version}")
-                            extract_path = self._download_and_extract_plugin_from_github(manifest, release_info, latest_version)
-                            self.discovered_manifests[manifest] = extract_path
+                            log('info', f"Plugin {manifest["name"]}'s latest version is {latest_version}")
+                            new_plugin = self._download_and_extract_plugin_from_github(manifest, release_info, latest_version)
+                            self.discovered_manifests[new_plugin[0]] = new_plugin[1]
                         else:
-                            log('error', f"Failed to check for updates for {manifest.name}: {response.text}")
+                            log('error', f"Failed to check for updates for {manifest["name"]}: {response.text}")
                     except Exception as e:
-                        log('error', f"Error downloading new plugin {manifest.name}: {e}")
-                elif manifest.source.type == "url" and isinstance(manifest.source, UrlPluginSource):
-                    log('debug', f"Plugin {manifest.name} has a URL source.")
+                        log('error', f"Error downloading new plugin {manifest["name"]}: {e}")
+                elif manifest["source"]["type"] == "url":
+                    log('debug', f"Plugin {manifest["name"]} has a URL source.")
                     
                     # Get latest manifest from url source, then compare versions with current manifest
                     try:
-                        response = requests.get(manifest.source.latest_manifest_url)
+                        response = requests.get(manifest["source"]["latest_manifest_url"])
                         if response.status_code == 200:
-                            latest_manifest = PluginManifest(response.text)
-                            log('info', f"Plugin {manifest.name}'s latest version is {latest_manifest.version}")
+                            latest_manifest: PluginManifest = json.loads(response.text)
+                            log('info', f"Plugin {manifest["name"]}'s latest version is {latest_manifest["version"]}")
                             
                             if not hasattr(manifest, 'version'):
-                                log('error', f"Plugin {manifest.name} does not have a version defined in its manifest.")
+                                log('error', f"Plugin {manifest["name"]} does not have a version defined in its manifest.")
                                 continue
-                            latest_version = Version(latest_manifest.version.lstrip('v'))
+                            latest_version = Version(latest_manifest["version"].lstrip('v'))
 
-                            log('info', f"Installing new plugin {manifest.name} {latest_version}")
-                            extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, manifest.guid))
+                            log('info', f"Installing new plugin {manifest["name"]} {latest_version}")
+                            extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, manifest["guid"]))
                             self._remove_plugin_folder(extract_path)
                             os.makedirs(extract_path, exist_ok=True)
 
                             # Download the plugin zip file
-                            zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{manifest.name}-{latest_version}.zip"))
+                            zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{manifest["name"]}-{latest_version}.zip"))
                             os.makedirs(self.PLUGIN_DL_FOLDER, exist_ok=True)
                             with open(zip_file_path, 'wb') as zip_file:
-                                zip_file.write(requests.get(manifest.source.download_url).content)
+                                zip_file.write(requests.get(manifest["source"]["download_url"]).content)
 
                             # Extract the zip file
                             import zipfile
                             with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
                                 zip_ref.extractall(extract_path)
-                            log('info', f"Extracted plugin {manifest.name} to {self.PLUGIN_FOLDER}")
+                            log('info', f"Extracted plugin {manifest["name"]} to {self.PLUGIN_FOLDER}")
+
+                            # Read new manifest.json
+                            manifest_path = os.path.join(extract_path, "manifest.json")
+                            if not os.path.exists(manifest_path):
+                                log('error', f"Manifest file {manifest_path} does not exist after extraction.")
+                                raise FileNotFoundError(f"Manifest file {manifest_path} does not exist after extraction.")
+                            with open(manifest_path, "r") as f:
+                                json_str = f.read()
+                                new_manifest: PluginManifest = json.loads(json_str)
+                            log('debug', f"Loaded manifest for {new_manifest["name"]} from extracted folder.")
 
                             # Add the new plugin to the discovered manifests
-                            self.discovered_manifests[manifest] = extract_path
+                            self.discovered_manifests[extract_path] = new_manifest
                         else:
-                            log('error', f"Failed to check for updates for {manifest.name}: {response.text}")
+                            log('error', f"Failed to check for updates for {manifest["name"]}: {response.text}")
                     except Exception as e:
-                        log('error', f"Error downloading new plugin {manifest.name}: {e}")
+                        log('error', f"Error downloading new plugin {manifest["name"]}: {e}")
                 else:
-                    log('error', f"Plugin {manifest.name} does not have a valid source to download from. Skipping installation.")
+                    log('error', f"Plugin {manifest["name"]} does not have a valid source to download from. Skipping installation.")
 
         print(json.dumps({"type": "plugins_changed", "message": "Installed plugins have been changed. Please restart the application."}) + '\n', flush=True)
 
     def register_actions(self, helper: PluginHelper) -> None:
         """Register all actions for each plugin."""
         for module in self.plugin_list.values():
-            log('debug', f"Registering Actions for {module.plugin_manifest.name}")
+            log('debug', f"Registering Actions for {module.plugin_manifest["name"]}")
             try:
                 module.register_actions(helper)
             except Exception as e:
-                log('error', f"Failed to register actions for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to register actions for {module.plugin_manifest["name"]}: {e}")
 
     def register_projections(self, helper: PluginHelper):
         """Register all projections for each plugin."""
         for module in self.plugin_list.values():
-            log('debug', f"Registering Projections for {module.plugin_manifest.name}")
+            log('debug', f"Registering Projections for {module.plugin_manifest["name"]}")
             try:
                 module.register_projections(helper)
             except Exception as e:
-                log('error', f"Failed to register projections for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to register projections for {module.plugin_manifest["name"]}: {e}")
     
     def register_sideeffects(self, helper: PluginHelper):
         """Register all side effects for each plugin."""
         for module in self.plugin_list.values():
-            log('debug', f"Registering Side-Effects for {module.plugin_manifest.name}")
+            log('debug', f"Registering Side-Effects for {module.plugin_manifest["name"]}")
             try:
                 module.register_sideeffects(helper)
             except Exception as e:
-                log('error', f"Failed to register side effects for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to register side effects for {module.plugin_manifest["name"]}: {e}")
     
     def register_settings(self):
         """Register all settings for each plugin."""
         for module in self.plugin_list.values():
-            log('debug', f"Registering Settings for {module.plugin_manifest.name}")
+            log('debug', f"Registering Settings for {module.plugin_manifest["name"]}")
             if module.settings_config is not None:
                 # Check if the settings config is already registered
                 self.plugin_settings_configs.append(module.settings_config)
@@ -452,36 +485,36 @@ class PluginManager:
     def register_prompt_event_handlers(self, helper: PluginHelper):
         """Register all prompt event handlers for each plugin. Used to add to the prompt in response to events."""
         for module in self.plugin_list.values():
-            log('debug', f"Registering Prompt Generators for {module.plugin_manifest.name}")
+            log('debug', f"Registering Prompt Generators for {module.plugin_manifest["name"]}")
             try:
                 module.register_prompt_event_handlers(helper)
             except Exception as e:
-                log('error', f"Failed to register prompt generators for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to register prompt generators for {module.plugin_manifest["name"]}: {e}")
     
     def register_status_generators(self, helper: PluginHelper):
         """Register all status generators for each plugin. Used to add to the prompt context, much like ship info."""
         for module in self.plugin_list.values():
-            log('debug', f"Registering status Generators for {module.plugin_manifest.name}")
+            log('debug', f"Registering status Generators for {module.plugin_manifest["name"]}")
             try:
                 module.register_status_generators(helper)
             except Exception as e:
-                log('error', f"Failed to register status generators for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to register status generators for {module.plugin_manifest["name"]}: {e}")
     
     def on_chat_stop(self, helper: PluginHelper):
         """
         Executed when the chat is stopped, and will call the on_chat_stop hook for each plugin.
         """
         for module in self.plugin_list.values():
-            log('debug', f"Executing on_chat_stop hook for {module.plugin_manifest.name}")
+            log('debug', f"Executing on_chat_stop hook for {module.plugin_manifest["name"]}")
             try:
                 module.on_chat_stop(helper)
             except Exception as e:
-                log('error', f"Failed to execute on_chat_stop hook for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to execute on_chat_stop hook for {module.plugin_manifest["name"]}: {e}")
 
     def register_event_classes(self) -> list[type[Event]]:
         plugin_event_classes: list[type[Event]] = []
         for module in self.plugin_list.values():
-            log('debug', f"Registering Event classes for {module.plugin_manifest.name}")
+            log('debug', f"Registering Event classes for {module.plugin_manifest["name"]}")
             if module.event_classes is not None:
                 # Check if the settings config is already registered
                 plugin_event_classes += module.event_classes
@@ -489,11 +522,11 @@ class PluginManager:
 
     def register_should_reply_handlers(self, helper: PluginHelper):
         for module in self.plugin_list.values():
-            log('debug', f"Registering should_reply handlers for {module.plugin_manifest.name}")
+            log('debug', f"Registering should_reply handlers for {module.plugin_manifest["name"]}")
             try:
                 module.register_should_reply_handlers(helper)
             except Exception as e:
-                log('error', f"Failed to register should_reply handlers for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to register should_reply handlers for {module.plugin_manifest["name"]}: {e}")
 
     
     def on_plugin_helper_ready(self, helper: PluginHelper):
@@ -502,8 +535,8 @@ class PluginManager:
         This is a good time to do any additional setup that requires the PluginHelper.
         """
         for module in self.plugin_list.values():
-            log('debug', f"Executing on_plugin_helper_ready hook for {module.plugin_manifest.name}")
+            log('debug', f"Executing on_plugin_helper_ready hook for {module.plugin_manifest["name"]}")
             try:
                 module.on_plugin_helper_ready(helper)
             except Exception as e:
-                log('error', f"Failed to execute on_plugin_helper_ready hook for {module.plugin_manifest.name}: {e}")
+                log('error', f"Failed to execute on_plugin_helper_ready hook for {module.plugin_manifest["name"]}: {e}")

--- a/src/lib/PluginManager.py
+++ b/src/lib/PluginManager.py
@@ -1,4 +1,6 @@
 from abc import ABC
+from dataclasses import asdict
+from dis import disco
 import importlib
 import importlib.util
 import json
@@ -9,9 +11,10 @@ from typing import Any, Callable, Literal, Self, TypedDict, cast, final
 
 import openai
 import requests
+from semantic_version import Version
 
 from .PluginBase import PluginBase
-from .PluginHelper import PluginHelper, PluginManifest
+from .PluginHelper import GitHubPluginSource, PluginHelper, PluginManifest, UrlPluginSource
 from .PluginSettingDefinitions import PluginSettings
 from .ScreenReader import ScreenReader
 from .Logger import log
@@ -27,6 +30,7 @@ class PluginManager:
     def __init__(self):
         self.plugin_list: dict[str, PluginBase] = {}
         self.plugin_settings_configs: list[PluginSettings] = []
+        self.discovered_manifests: dict[PluginManifest, str] = {}
         self.PLUGIN_FOLDER: str = "plugins"
         self.PLUGIN_DL_FOLDER: str = "plugin_downloads"
         self.PLUGIN_DEPENDENCIES_FOLDER: str = "deps"
@@ -85,6 +89,9 @@ class PluginManager:
                     with open(os.path.join(subfolder_path, "manifest.json"), "r") as f:
                         json_str = f.read()
                         manifest = PluginManifest(json_str)
+                    
+                    # Add manifest to discovered_manifests array
+                    self.discovered_manifests.update({manifest: subfolder_path})
 
                     log('debug', f"Loaded manifest for {manifest.name}")
                     log('debug', f"Entry point: {manifest.entrypoint}")
@@ -105,6 +112,13 @@ class PluginManager:
                     self.plugin_list[module_name] = module
             except Exception as e:
                 log('error', f"Failed to load plugin {file}: {e}")
+
+        # Notify frontend about the discovered plugin manifests.
+        print(json.dumps({
+            "type": "installed_plugin_list",
+            "plugins": list([asdict(obj) for obj in self.discovered_manifests.keys()]),
+        }) + '\n', flush=True)
+
         return self
     
     def check_for_plugin_updates(self):
@@ -113,14 +127,16 @@ class PluginManager:
         If the source is a GitHub repository, it will the release information from the GitHub API.
         If the source is not a GitHub repository, it will skip the update check, for now. More will be implemented later.
         """
-        from semantic_version import Version
-
         available_updates = []
 
         for key in self.plugin_list.keys():
             module = self.plugin_list[key]
 
-            if module.plugin_manifest.source and module.plugin_manifest.source.type == "github":
+            if module.plugin_manifest.source is None:
+                log('debug', f"Plugin {module.plugin_manifest.name} does not have a source defined in its manifest. Skipping update check.")
+                continue
+
+            if module.plugin_manifest.source.type == "github" and isinstance(module.plugin_manifest.source, GitHubPluginSource):
                 log('debug', f"Checking for updates for plugin {module.plugin_manifest.name} from {module.plugin_manifest.source.repo}")
                 try:
                     # Get the latest release information from GitHub
@@ -152,6 +168,36 @@ class PluginManager:
                         log('error', f"Failed to check for updates for {module.plugin_manifest.name}: {response.text}")
                 except Exception as e:
                     log('error', f"Error checking for updates for {module.plugin_manifest.name}: {e}")
+            elif module.plugin_manifest.source.type == "url" and isinstance(module.plugin_manifest.source, UrlPluginSource):
+                log('debug', f"Plugin {module.plugin_manifest.name} has a URL source.")
+
+                # Get latest manifest from url source, then compare versions with current manifest
+                try:
+                    response = requests.get(module.plugin_manifest.source.latest_manifest_url)
+                    if response.status_code == 200:
+                        latest_manifest = PluginManifest(response.text)
+                        log('info', f"Plugin {module.plugin_manifest.name}'s latest version is {latest_manifest.version}")
+                        
+                        # Compare with the current version, using SemVer
+                        if not hasattr(module.plugin_manifest, 'version'):
+                            log('error', f"Plugin {module.plugin_manifest.name} does not have a version defined in its manifest.")
+                            continue
+                        current_version = Version(module.plugin_manifest.version)
+                        latest_version = Version(latest_manifest.version.lstrip('v'))
+
+                        log('debug', f"Current version: {current_version}, Latest version: {latest_version}")
+                        if latest_version > current_version:
+                            log('info', f"Plugin {module.plugin_manifest.name} has an update available: {latest_version} (current: {current_version})")
+                            available_updates.append({
+                                "plugin_name": module.plugin_manifest.name,
+                                "current_version": str(current_version),
+                                "latest_version": str(latest_version),
+                                "repo": None,
+                                'release_url': latest_manifest.repository
+                            })
+                except Exception as e:
+                    log('error', f"Error checking for updates for {module.plugin_manifest.name}: {e}")
+        log('info', f"Found {len(available_updates)} plugins with available updates.")
 
         # Notify frontend about the updates
         print(json.dumps({
@@ -159,65 +205,213 @@ class PluginManager:
             "available_updates": available_updates
         }) + '\n', flush=True)
     
+    def _remove_plugin_folder(self, path: str) -> None:
+        """Remove a plugin folder if it exists."""
+        if os.path.exists(path):
+            log('debug', f"Removing plugin folder {path}.")
+            import shutil
+            shutil.rmtree(path, ignore_errors=True)
+
+    def _download_and_extract_plugin_from_github(self, manifest: PluginManifest, release_info: dict, latest_version: str) -> str:
+        """Download and extract a plugin from GitHub release assets. Returns the extract path."""
+
+        if not isinstance(manifest.source, GitHubPluginSource):
+            log('debug', f"Plugin {manifest.name} does not have a valid GitHub source defined in its manifest.")
+            raise Exception(f"Plugin {manifest.name} does not have a valid GitHub source defined in its manifest.")
+
+        # Download the release asset
+        asset = release_info['assets'][0]
+        asset_response = requests.get(
+            url=f"https://api.github.com/repos/{manifest.source.repo}/releases/assets/{asset['id']}",
+            headers={"Accept": "application/octet-stream"}
+        )
+        if asset_response.status_code != 200:
+            raise Exception(f"Failed to download asset: {asset_response.text}")
+
+        # Save the zip file
+        zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{manifest.name}-{latest_version}.zip"))
+        os.makedirs(self.PLUGIN_DL_FOLDER, exist_ok=True)
+        with open(zip_file_path, 'wb') as zip_file:
+            zip_file.write(asset_response.content)
+        log('info', f"Downloaded plugin {manifest.name} to {zip_file_path}")
+
+        # Create valid name for new folder
+        import re
+        new_plugin_folder_name = re.sub(r'[<>:"/\\|?*\x00-\x1F]', "", manifest.name)
+        new_plugin_folder_name = new_plugin_folder_name.strip().rstrip(". ")
+        extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, new_plugin_folder_name))
+
+        # Remove old directory if it exists
+        self._remove_plugin_folder(extract_path)
+        os.makedirs(extract_path, exist_ok=True)
+
+        # Extract zip file
+        import zipfile
+        with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
+            zip_ref.extractall(extract_path)
+        log('info', f"Extracted plugin {manifest.name} to {self.PLUGIN_FOLDER}")
+
+        return extract_path
+
     def update_plugins(self):
         """
         Download and install updates for plugins that have an update available.
         """
-        from semantic_version import Version
+        for plugin_manifest in self.discovered_manifests.keys():
+            old_path = self.discovered_manifests[plugin_manifest]
 
-        for key in self.plugin_list.keys():
-            module = self.plugin_list[key]
+            if plugin_manifest.source is None:
+                log('debug', f"Plugin {plugin_manifest.name} does not have a source defined in its manifest. Skipping update check.")
+                continue
 
-            if module.plugin_manifest.source and module.plugin_manifest.source.type == "github":
-                log('debug', f"Checking for updates for plugin {module.plugin_manifest.name} from {module.plugin_manifest.source.repo}")
+            if plugin_manifest.source.type == "github" and isinstance(plugin_manifest.source, GitHubPluginSource):
+                log('debug', f"Checking for updates for plugin {plugin_manifest.name} from {plugin_manifest.source.repo}")
                 try:
-                    # Get the latest release information from GitHub
                     response = requests.get(
-                        url=f"https://api.github.com/repos/{module.plugin_manifest.source.repo}/releases/latest"
+                        url=f"https://api.github.com/repos/{plugin_manifest.source.repo}/releases/latest"
                     )
                     if response.status_code == 200:
                         release_info = cast(dict[str, Any], response.json())
                         latest_version = cast(str, release_info.get("tag_name", "unknown"))
-                        log('info', f"Plugin {module.plugin_manifest.name}'s latest version is {latest_version}")
-                        
-                        # Compare with the current version, using SemVer
-                        if not hasattr(module.plugin_manifest, 'version'):
-                            log('error', f"Plugin {module.plugin_manifest.name} does not have a version defined in its manifest.")
+                        log('info', f"Plugin {plugin_manifest.name}'s latest version is {latest_version}")
+
+                        if not hasattr(plugin_manifest, 'version'):
+                            log('error', f"Plugin {plugin_manifest.name} does not have a version defined in its manifest.")
                             continue
-                        current_version = Version(module.plugin_manifest.version)
-                        latest_version = Version(latest_version.lstrip('v'))  # Remove 'v'
+                        current_version = Version(plugin_manifest.version)
+                        latest_version_semver = Version(latest_version.lstrip('v'))
+                        log('debug', f"Current version: {current_version}, Latest version: {latest_version_semver}")
+                        if latest_version_semver > current_version:
+                            log('info', f"Installing update for plugin {plugin_manifest.name}. Updating from {current_version} to {latest_version_semver}")
+                            self._remove_plugin_folder(old_path)
+                            self.discovered_manifests[plugin_manifest] = self._download_and_extract_plugin_from_github(plugin_manifest, release_info, latest_version)
+                    else:
+                        log('error', f"Failed to check for updates for {plugin_manifest.name}: {response.text}")
+                except Exception as e:
+                    log('error', f"Error checking for updates for {plugin_manifest.name}: {e}")
+            elif plugin_manifest.source.type == "url" and isinstance(plugin_manifest.source, UrlPluginSource):
+                log('debug', f"Plugin {plugin_manifest.name} has a URL source.")
+
+                # Get latest manifest from url source, then compare versions with current manifest
+                try:
+                    response = requests.get(plugin_manifest.source.latest_manifest_url)
+                    if response.status_code == 200:
+                        latest_manifest = PluginManifest(response.text)
+                        log('info', f"Plugin {plugin_manifest.name}'s latest version is {latest_manifest.version}")
+
+                        if not hasattr(plugin_manifest, 'version'):
+                            log('error', f"Plugin {plugin_manifest.name} does not have a version defined in its manifest.")
+                            continue
+                        current_version = Version(plugin_manifest.version)
+                        latest_version = Version(latest_manifest.version.lstrip('v'))
+
                         log('debug', f"Current version: {current_version}, Latest version: {latest_version}")
                         if latest_version > current_version:
-                            log('info', f"Installing update for plugin {module.plugin_manifest.name}. Updating from {latest_version} to {current_version})")
-                            # Download and install the update from GitHub Releases
-                            release_response = requests.get(
-                                url=f"https://api.github.com/repos/{module.plugin_manifest.source.repo}/releases/assets/{release_info['assets'][0]['id']}",
-                                headers={"Accept": "application/octet-stream"}
-                            )
-
-                            if release_response.status_code == 200:
-                                # Save the zip file to the plugin downloads folder
-                                zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{module.plugin_manifest.name}-{latest_version}.zip"))
-                                with open(zip_file_path, 'wb') as zip_file:
-                                    zip_file.write(response.content)
-                                log('info', f"Downloaded update for {module.plugin_manifest.name} to {zip_file_path}")
-
-                                # Extract zip file to the plugin folder
-                                import zipfile
-                                with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
-                                    extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, key))
-                                    if os.path.exists(extract_path):
-                                        os.rmdir(extract_path)  # Remove old directory if it exists
-                                    os.makedirs(extract_path)
-                                    zip_ref.extractall(extract_path)
-                                log('info', f"Extracted update for {module.plugin_manifest.name} to {self.PLUGIN_FOLDER}")
-                    else:
-                        log('error', f"Failed to check for updates for {module.plugin_manifest.name}: {response.text}")
+                            log('info', f"Installing update for plugin {plugin_manifest.name}. Updating from {current_version} to {latest_version}")
+                            self._remove_plugin_folder(old_path)
+                            extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, plugin_manifest.guid))
+                            os.makedirs(extract_path, exist_ok=True)
+                            
+                            # Download the plugin zip file
+                            zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{plugin_manifest.name}-{latest_version}.zip"))
+                            os.makedirs(self.PLUGIN_DL_FOLDER, exist_ok=True)
+                            with open(zip_file_path, 'wb') as zip_file:
+                                zip_file.write(requests.get(plugin_manifest.source.download_url).content)
+                            log('info', f"Downloaded plugin {plugin_manifest.name} to {zip_file_path}")
+                            # Extract the zip file
+                            import zipfile
+                            with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
+                                zip_ref.extractall(extract_path)
+                            log('info', f"Extracted plugin {plugin_manifest.name} to {self.PLUGIN_FOLDER}")
+                            
+                            # Update the discovered manifests
+                            self.discovered_manifests[plugin_manifest] = extract_path
                 except Exception as e:
-                    log('error', f"Error checking for updates for {module.plugin_manifest.name}: {e}")
+                    log('error', f"Error checking for updates for {plugin_manifest.name}: {e}")
 
-        # Shutdown the application to apply updates
-        print(json.dumps({"type": "plugin_updates_installed", "message": "Plugins have been updated. Please restart the application."}) + '\n', flush=True)
+        print(json.dumps({"type": "plugins_changed", "message": "Plugins have been updated. Please restart the application."}) + '\n', flush=True)
+
+    def change_installed_plugins(self, new_plugin_list: list[PluginManifest]) -> None:
+        """
+        Change the installed plugins to the new plugin list.
+        This will remove all installed plugins not present in the new list, and install the new ones.
+        """
+        log('info', f"Changing installed plugins to {len(new_plugin_list)} plugins.")
+
+        # Remove discovered plugins not in the new list, by guid
+        for manifest in self.discovered_manifests.keys():
+            old_path = self.discovered_manifests[manifest]
+            if manifest.guid not in [p.guid for p in new_plugin_list]:
+                log('debug', f"Uninstalling plugin {manifest.name}.")
+                self._remove_plugin_folder(old_path)
+                del self.discovered_manifests[manifest]
+
+        # Download and install new plugins
+        for manifest in new_plugin_list:
+            if manifest.guid not in [m.guid for m in self.discovered_manifests.keys()]:
+                log('debug', f"Downloading new plugin {manifest.name}.")
+                
+                if manifest.source is None:
+                    log('debug', f"Plugin {manifest.name} does not have a source defined in its manifest. Skipping update check.")
+                    continue
+
+                if manifest.source.type == "github" and isinstance(manifest.source, GitHubPluginSource):
+                    try:
+                        response = requests.get(
+                            url=f"https://api.github.com/repos/{manifest.source.repo}/releases/latest"
+                        )
+                        if response.status_code == 200:
+                            release_info = cast(dict[str, Any], response.json())
+                            latest_version = cast(str, release_info.get("tag_name", "unknown"))
+                            log('info', f"Plugin {manifest.name}'s latest version is {latest_version}")
+                            extract_path = self._download_and_extract_plugin_from_github(manifest, release_info, latest_version)
+                            self.discovered_manifests[manifest] = extract_path
+                        else:
+                            log('error', f"Failed to check for updates for {manifest.name}: {response.text}")
+                    except Exception as e:
+                        log('error', f"Error downloading new plugin {manifest.name}: {e}")
+                elif manifest.source.type == "url" and isinstance(manifest.source, UrlPluginSource):
+                    log('debug', f"Plugin {manifest.name} has a URL source.")
+                    
+                    # Get latest manifest from url source, then compare versions with current manifest
+                    try:
+                        response = requests.get(manifest.source.latest_manifest_url)
+                        if response.status_code == 200:
+                            latest_manifest = PluginManifest(response.text)
+                            log('info', f"Plugin {manifest.name}'s latest version is {latest_manifest.version}")
+                            
+                            if not hasattr(manifest, 'version'):
+                                log('error', f"Plugin {manifest.name} does not have a version defined in its manifest.")
+                                continue
+                            latest_version = Version(latest_manifest.version.lstrip('v'))
+
+                            log('info', f"Installing new plugin {manifest.name} {latest_version}")
+                            extract_path = os.path.abspath(os.path.join('.', self.PLUGIN_FOLDER, manifest.guid))
+                            self._remove_plugin_folder(extract_path)
+                            os.makedirs(extract_path, exist_ok=True)
+
+                            # Download the plugin zip file
+                            zip_file_path = os.path.abspath(os.path.join('.', self.PLUGIN_DL_FOLDER, f"{manifest.name}-{latest_version}.zip"))
+                            os.makedirs(self.PLUGIN_DL_FOLDER, exist_ok=True)
+                            with open(zip_file_path, 'wb') as zip_file:
+                                zip_file.write(requests.get(manifest.source.download_url).content)
+
+                            # Extract the zip file
+                            import zipfile
+                            with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
+                                zip_ref.extractall(extract_path)
+                            log('info', f"Extracted plugin {manifest.name} to {self.PLUGIN_FOLDER}")
+
+                            # Add the new plugin to the discovered manifests
+                            self.discovered_manifests[manifest] = extract_path
+                        else:
+                            log('error', f"Failed to check for updates for {manifest.name}: {response.text}")
+                    except Exception as e:
+                        log('error', f"Error downloading new plugin {manifest.name}: {e}")
+                else:
+                    log('error', f"Plugin {manifest.name} does not have a valid source to download from. Skipping installation.")
+
+        print(json.dumps({"type": "plugins_changed", "message": "Installed plugins have been changed. Please restart the application."}) + '\n', flush=True)
 
     def register_actions(self, helper: PluginHelper) -> None:
         """Register all actions for each plugin."""

--- a/src/lib/Projections.py
+++ b/src/lib/Projections.py
@@ -37,6 +37,15 @@ class EventCounter(Projection):
     def process(self, event: Event) -> None:
         self.state["count"] += 1
 
+class FakeDamageLevel(Projection[int]):
+    @override
+    def get_default_state(self) -> int:
+        return 0
+
+    @override
+    def process(self, event: Event) -> None:
+        if isinstance(event, SetFakeDamageEvent) and event.status.get("event") == "Status":
+            self.state = event.status
 
 class CurrentStatus(Projection[Status]):
     @override

--- a/ui/angular.json
+++ b/ui/angular.json
@@ -67,7 +67,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "port": 1420
+            "port": 4200
           },
           "configurations": {
             "production": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,6 +24,7 @@
         "@tauri-apps/plugin-http": "^2.4.4",
         "@tauri-apps/plugin-log": "^2.3.1",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.2"
@@ -4573,9 +4574,9 @@
       "dev": true
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.2.0.tgz",
-      "integrity": "sha512-R8epOeZl1eJEl603aUMIGb4RXlhPjpgxbGVEaqY+0G5JG9vzV/clNlzTeqc+NLYXVqXcn8mb4c5b9pJIUDEyAg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.6.0.tgz",
+      "integrity": "sha512-hRNcdercfgpzgFrMXWwNDBN0B7vNzOzRepy6ZAmhxi5mDLVPNrTpo9MGg2tN/F7JRugj4d2aF7E1rtPXAHaetg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
@@ -4791,6 +4792,14 @@
       "integrity": "sha512-hHsJ9RPWpZvZEPVFaL+d25gABMUMOf/A6ESXnvf/ii9guTukj58WXsAE/SOysXRIhej7kseRCxnOnIMpSCdUsQ==",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.0.tgz",
+      "integrity": "sha512-0DNj6u+9csODiV4seSxxRbnLpeGYdojlcctCuLOCgpH9X3+ckVZIEj6H7tRQ7zqWr7kSTEWnrxtAdBb0FbtrmQ==",
+      "dependencies": {
+        "@tauri-apps/api": "^2.6.0"
       }
     },
     "node_modules/@tufjs/canonical-json": {
@@ -16941,9 +16950,9 @@
       "dev": true
     },
     "@tauri-apps/api": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.2.0.tgz",
-      "integrity": "sha512-R8epOeZl1eJEl603aUMIGb4RXlhPjpgxbGVEaqY+0G5JG9vzV/clNlzTeqc+NLYXVqXcn8mb4c5b9pJIUDEyAg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.6.0.tgz",
+      "integrity": "sha512-hRNcdercfgpzgFrMXWwNDBN0B7vNzOzRepy6ZAmhxi5mDLVPNrTpo9MGg2tN/F7JRugj4d2aF7E1rtPXAHaetg=="
     },
     "@tauri-apps/cli": {
       "version": "2.2.7",
@@ -17055,6 +17064,14 @@
       "integrity": "sha512-hHsJ9RPWpZvZEPVFaL+d25gABMUMOf/A6ESXnvf/ii9guTukj58WXsAE/SOysXRIhej7kseRCxnOnIMpSCdUsQ==",
       "requires": {
         "@tauri-apps/api": "^2.0.0"
+      }
+    },
+    "@tauri-apps/plugin-process": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.0.tgz",
+      "integrity": "sha512-0DNj6u+9csODiV4seSxxRbnLpeGYdojlcctCuLOCgpH9X3+ckVZIEj6H7tRQ7zqWr7kSTEWnrxtAdBb0FbtrmQ==",
+      "requires": {
+        "@tauri-apps/api": "^2.6.0"
       }
     },
     "@tufjs/canonical-json": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "@tauri-apps/plugin-http": "^2.4.4",
     "@tauri-apps/plugin-log": "^2.3.1",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.2"

--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.covas-next.ui",
   "build": {
     "beforeDevCommand": "npx mkdirp ../dist/Chat && npm run start",
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://localhost:4200",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist/covas-next-ui/browser"
   },

--- a/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.css
+++ b/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.css
@@ -1,0 +1,8 @@
+mat-dialog-content {
+  min-width: 300px;
+  margin-bottom: 16px;
+}
+
+p {
+  margin: 8px 0;
+} 

--- a/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.css
+++ b/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.css
@@ -5,4 +5,21 @@ mat-dialog-content {
 
 p {
   margin: 8px 0;
-} 
+}
+
+mat-selection-list {
+  overflow-y: scroll;
+  height: 100%;
+}
+
+mat-list-option[aria-selected="true"] {
+  background-color: #333;
+}
+
+mat-card {
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+

--- a/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.html
+++ b/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.html
@@ -1,0 +1,31 @@
+<h2 mat-dialog-title>Plugin Manager</h2>
+<mat-dialog-content>
+  <p>Here you can manage your installed plugins, and install new ones.</p>
+  <mat-grid-list cols="2">
+    <mat-grid-tile>
+      <p *ngIf="is_loading">Loading plugins...</p>
+      <p *ngIf="!is_loading && plugin_list.length === 0">No plugins installed and none were discovered from the repository.</p>
+      <<table mat-table [dataSource]="plugin_list" class="mat-elevation-z8" *ngIf="!is_loading && plugin_list.length > 0" (selectionChang)="onSelectedPluginChanged($event.options)" [multiple]="false" [hideSingleSelectionIndicator]="true">
+        @for (plugin of plugin_list; track plugin) {
+          <mat-list-option [value]="plugin"><mat-checkbox [checked]="plugin[0]" (change)="onPluginsChanged($event)" (click)="$event.stopPropagation()"></mat-checkbox> {{ plugin[1].name }}</mat-list-option>
+        }
+      </table>
+    </mat-grid-tile>
+    <mat-grid-tile>
+      <mat-card *ngIf="selected_plugin !== null">
+        <mat-card-header>
+          <mat-card-title>{{ selected_plugin[1].name }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p><strong>Version:</strong> {{ selected_plugin[1].version }}</p>
+          <p><strong>Description:</strong> {{ selected_plugin[1].description }}</p>
+          <p><strong>Repository:</strong> <a [href]="selected_plugin[1].repository" target="_blank">{{ selected_plugin[1].repository }}</a></p>
+        </mat-card-content>
+      </mat-card>
+    </mat-grid-tile>
+  </mat-grid-list>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancelClick()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="onInstallClick()" [disabled]="!is_modified">Install/Remove selected plugins</button>
+</mat-dialog-actions> 

--- a/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.ts
+++ b/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.ts
@@ -1,0 +1,127 @@
+import { Component, Inject } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+    MAT_DIALOG_DATA,
+    MatDialogModule,
+    MatDialogRef,
+} from "@angular/material/dialog";
+import { MatButtonModule } from "@angular/material/button";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { MatCard, MatCardHeader, MatCardTitle, MatCardSubtitle, MatCardContent } from "@angular/material/card";
+import { MatListItem, MatList } from "@angular/material/list";
+import { MatCheckbox } from "@angular/material/checkbox";
+import { PluginIndexEntry } from "../../services/plugin-manager.service";
+
+export interface PluginSource {
+    type: string;
+    repo: string;
+    asset_name: string;
+}
+
+export interface PluginManifest {
+    guid: string;
+    name: string;
+    author: string;
+    version: string;
+    repository: string;
+    description: string;
+    entrypoint: string;
+    source: PluginSource | null;
+}
+
+export interface PluginManagerDialogData {
+    installed_plugins: PluginManifest[];
+}
+
+@Component({
+    selector: "app-plugin-manager-dialog",
+    standalone: true,
+    imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatExpansionModule,
+    MatCard,
+    MatCardHeader,
+    MatCardTitle,
+    MatCardSubtitle,
+    MatCardContent,
+    MatListItem,
+    MatList,
+    MatCheckbox
+],
+    templateUrl: "./plugin-manager-dialog.component.html",
+    styleUrl: "./plugin-manager-dialog.component.css",
+})
+export class PluginManagerDialogComponent {
+    public is_loading = true;
+    public plugin_list: [boolean, PluginManifest][] = [];
+
+    constructor(
+        public dialogRef: MatDialogRef<PluginManagerDialogComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: PluginManagerDialogData,
+    ) {}
+
+    ngOnInit(): void {
+        // TODO: Update url before release
+        fetch("https://raw.githubusercontent.com/MaverickMartyn/Elite-Dangerous-AI-Integration/refs/heads/feat/plugin-install-and-updates/docs/plugins/plugin_index.json")
+        .then((response) => response.json())
+        .then((json_resp) => {
+            let plugin_index = json_resp as PluginIndexEntry[];
+            if (plugin_index && Array.isArray(plugin_index)) {
+                // Each plugin index entry should have a name and latest_manifest_url
+                // Download the latest manifest for each plugin and store it in the available_plugins_list
+                let promises = plugin_index.map(entry => {
+                    return fetch(entry.latest_manifest_url)
+                    .then((response) => response.json())
+                    .then((manifest_obj) => {
+                        if (manifest_obj?.guid && manifest_obj?.name) {
+                            return manifest_obj as PluginManifest;
+                        } else {
+                            console.error("Invalid plugin manifest format:", manifest_obj);
+                            return null;
+                        }
+                    })
+                    .catch((manifest_error) => {
+                        console.error("Failed to fetch plugin manifest:", manifest_error);
+                    });
+                });
+                Promise.all(promises).then((manifests) => {
+                    // After all manifests are fetched, open the dialog
+                    // Strip null values from the manifests
+                    this.plugin_list = manifests.filter(m => m !== null)
+                        .map(m => [
+                            this.data.installed_plugins.map(ip => ip.guid).includes(m?.guid || ""),
+                            m
+                        ] as [boolean, PluginManifest]);
+                    
+                    // Add installed plugins to the list, if they are not already present
+                    this.data.installed_plugins.forEach(installed_plugin => {
+                        if (!this.plugin_list.some(([_, plugin]) => plugin.guid === installed_plugin.guid)) {
+                            this.plugin_list.push([true, installed_plugin]);
+                        }
+                    });
+
+                    // Sort the plugin list by name
+                    this.plugin_list.sort((a, b) => a[1].name.localeCompare(b[1].name));
+                    
+                    this.is_loading = false;
+                });
+                    
+            } else {
+                console.error("Invalid plugin index format:", plugin_index);
+            }
+        })
+        .catch((error) => {
+            console.error("Failed to fetch plugin index:", error);
+        });
+    }
+
+    onCancelClick(): void {
+        this.dialogRef.close(false);
+    }
+
+    onInstallClick(): void {
+        this.dialogRef.close(this.plugin_list.filter(plugin => plugin[0]).map(plugin => plugin[1]));
+    }
+}

--- a/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.ts
+++ b/ui/src/app/components/plugin-manager-dialog/plugin-manager-dialog.component.ts
@@ -8,9 +8,11 @@ import {
 import { MatButtonModule } from "@angular/material/button";
 import { MatExpansionModule } from "@angular/material/expansion";
 import { MatCard, MatCardHeader, MatCardTitle, MatCardSubtitle, MatCardContent } from "@angular/material/card";
-import { MatListItem, MatList } from "@angular/material/list";
-import { MatCheckbox } from "@angular/material/checkbox";
+import { MatListItem, MatList, MatSelectionList, MatListModule, MatListOption } from "@angular/material/list";
+import { MatCheckbox, MatCheckboxChange } from "@angular/material/checkbox";
 import { PluginIndexEntry } from "../../services/plugin-manager.service";
+import {MatGridListModule} from '@angular/material/grid-list';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
 
 export interface PluginSource {
     type: string;
@@ -37,84 +39,115 @@ export interface PluginManagerDialogData {
     selector: "app-plugin-manager-dialog",
     standalone: true,
     imports: [
-    CommonModule,
-    MatDialogModule,
-    MatButtonModule,
-    MatExpansionModule,
-    MatCard,
-    MatCardHeader,
-    MatCardTitle,
-    MatCardSubtitle,
-    MatCardContent,
-    MatListItem,
-    MatList,
-    MatCheckbox
-],
+        CommonModule,
+        MatDialogModule,
+        MatButtonModule,
+        MatExpansionModule,
+        MatGridListModule,
+        MatCard,
+        MatCardHeader,
+        MatCardTitle,
+        MatCardSubtitle,
+        MatCardContent,
+        MatListItem,
+        MatSelectionList,
+        MatList,
+        MatCheckbox,
+        MatListModule,
+        FormsModule,
+        ReactiveFormsModule
+    ],
     templateUrl: "./plugin-manager-dialog.component.html",
     styleUrl: "./plugin-manager-dialog.component.css",
 })
 export class PluginManagerDialogComponent {
     public is_loading = true;
+    public is_modified = false;
+    public selected_plugin: [boolean, PluginManifest] | null = null;
     public plugin_list: [boolean, PluginManifest][] = [];
+    public form: FormGroup;
+    public pluginsControl = new FormControl();
 
     constructor(
         public dialogRef: MatDialogRef<PluginManagerDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: PluginManagerDialogData,
-    ) {}
+    ) {
+        this.form = new FormGroup({
+            clothes: this.pluginsControl,
+        });
+    }
 
     ngOnInit(): void {
         // TODO: Update url before release
         fetch("https://raw.githubusercontent.com/MaverickMartyn/Elite-Dangerous-AI-Integration/refs/heads/feat/plugin-install-and-updates/docs/plugins/plugin_index.json")
-        .then((response) => response.json())
-        .then((json_resp) => {
-            let plugin_index = json_resp as PluginIndexEntry[];
-            if (plugin_index && Array.isArray(plugin_index)) {
-                // Each plugin index entry should have a name and latest_manifest_url
-                // Download the latest manifest for each plugin and store it in the available_plugins_list
-                let promises = plugin_index.map(entry => {
-                    return fetch(entry.latest_manifest_url)
-                    .then((response) => response.json())
-                    .then((manifest_obj) => {
-                        if (manifest_obj?.guid && manifest_obj?.name) {
-                            return manifest_obj as PluginManifest;
-                        } else {
-                            console.error("Invalid plugin manifest format:", manifest_obj);
-                            return null;
-                        }
-                    })
-                    .catch((manifest_error) => {
-                        console.error("Failed to fetch plugin manifest:", manifest_error);
+            .then((response) => {
+                return response.json();
+            })
+            .then((json_resp) => {
+                let plugin_index = json_resp as PluginIndexEntry[];
+                if (plugin_index && Array.isArray(plugin_index)) {
+                    // Each plugin index entry should have a name and latest_manifest_url
+                    // Download the latest manifest for each plugin and store it in the available_plugins_list
+                    let promises = plugin_index.map(entry => {
+                        return fetch(entry.latest_manifest_url)
+                            .then((response) => {
+                                return response.json();
+                            })
+                            .then((manifest_obj) => {
+                                if (manifest_obj?.guid && manifest_obj?.name) {
+                                    return manifest_obj as PluginManifest;
+                                } else {
+                                    console.error("Invalid plugin manifest format:", manifest_obj);
+                                    return null;
+                                }
+                            })
+                            .catch((manifest_error) => {
+                                console.error("Failed to fetch plugin manifest:", manifest_error);
+                            });
                     });
-                });
-                Promise.all(promises).then((manifests) => {
-                    // After all manifests are fetched, open the dialog
-                    // Strip null values from the manifests
-                    this.plugin_list = manifests.filter(m => m !== null)
-                        .map(m => [
-                            this.data.installed_plugins.map(ip => ip.guid).includes(m?.guid || ""),
-                            m
-                        ] as [boolean, PluginManifest]);
-                    
-                    // Add installed plugins to the list, if they are not already present
-                    this.data.installed_plugins.forEach(installed_plugin => {
-                        if (!this.plugin_list.some(([_, plugin]) => plugin.guid === installed_plugin.guid)) {
-                            this.plugin_list.push([true, installed_plugin]);
-                        }
+                    Promise.all(promises).then((manifests) => {
+                        // After all manifests are fetched, open the dialog
+                        // Strip null values from the manifests
+                        this.plugin_list = manifests.filter(m => m !== null && m !== undefined)
+                            .map(m => [
+                                this.data.installed_plugins.map(ip => ip.guid).includes(m?.guid || ""),
+                                m
+                            ] as [boolean, PluginManifest]);
+
+                        // Add installed plugins to the list, if they are not already present
+                        this.data.installed_plugins.forEach(installed_plugin => {
+                            if (!this.plugin_list.some(([_, plugin]) => plugin.guid === installed_plugin.guid)) {
+                                this.plugin_list.push([true, installed_plugin]);
+                            }
+                        });
+
+                        // Sort the plugin list by name
+                        this.plugin_list.sort((a, b) => a[1].name.localeCompare(b[1].name));
+
+                        this.is_loading = false;
                     });
 
-                    // Sort the plugin list by name
-                    this.plugin_list.sort((a, b) => a[1].name.localeCompare(b[1].name));
-                    
-                    this.is_loading = false;
-                });
-                    
-            } else {
-                console.error("Invalid plugin index format:", plugin_index);
-            }
-        })
-        .catch((error) => {
-            console.error("Failed to fetch plugin index:", error);
-        });
+                } else {
+                    console.error("Invalid plugin index format:", plugin_index);
+                }
+            })
+            .catch((error) => {
+                console.error("Failed to fetch plugin index:", error);
+            });
+    }
+
+    onSelectedPluginChanged(options: MatListOption[]): void {
+        let selected_plugins = options.filter((v, i) => v.selected);
+        if (selected_plugins.length > 0) {
+            let plugin_opt = selected_plugins[0]
+            let plugin = plugin_opt.value as [boolean, PluginManifest];
+            this.selected_plugin = plugin;
+            console.log('Selected plugin: ' + plugin[1].name);
+        }
+    }
+
+    onPluginsChanged(event: MatCheckboxChange): void {
+        this.is_modified = true;
     }
 
     onCancelClick(): void {

--- a/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.css
+++ b/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.css
@@ -1,0 +1,8 @@
+mat-dialog-content {
+  min-width: 300px;
+  margin-bottom: 16px;
+}
+
+p {
+  margin: 8px 0;
+} 

--- a/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.html
+++ b/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.html
@@ -1,0 +1,15 @@
+<h2 mat-dialog-title>Plugin Update(s) Available</h2>
+<mat-dialog-content>
+  <p>One or more plugins have updates available:</p>
+  <ul>
+    <li *ngFor="let p_update of data.plugin_updates">
+      <strong>{{ p_update.name }}</strong> - {{ p_update.version }}
+      <a [href]="p_update.release_url" target="_blank">View Release in Browser</a>
+    </li>
+  </ul>
+  <p>Would you like to automatically download and install all plugin updates?</p>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onNoClick()">Not Now</button>
+  <button mat-raised-button color="primary" (click)="onDownloadClick()">Yes, please</button>
+</mat-dialog-actions> 

--- a/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.ts
+++ b/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.ts
@@ -1,0 +1,39 @@
+import { Component, Inject } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+    MAT_DIALOG_DATA,
+    MatDialogModule,
+    MatDialogRef,
+} from "@angular/material/dialog";
+import { MatButtonModule } from "@angular/material/button";
+import { PluginUpdateInfo } from "../../services/plugin-update.service";
+
+export interface PluginUpdateDialogData {
+    plugin_updates: PluginUpdateInfo[];
+}
+
+@Component({
+    selector: "app-plugin-update-dialog",
+    standalone: true,
+    imports: [
+        CommonModule,
+        MatDialogModule,
+        MatButtonModule,
+    ],
+    templateUrl: "./plugin-update-dialog.component.html",
+    styleUrl: "./plugin-update-dialog.component.css",
+})
+export class PluginUpdateDialogComponent {
+    constructor(
+        public dialogRef: MatDialogRef<PluginUpdateDialogComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: PluginUpdateDialogData,
+    ) {}
+
+    onNoClick(): void {
+        this.dialogRef.close(false);
+    }
+
+    onDownloadClick(): void {
+        this.dialogRef.close(true);
+    }
+}

--- a/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.ts
+++ b/ui/src/app/components/plugin-update-dialog/plugin-update-dialog.component.ts
@@ -6,7 +6,7 @@ import {
     MatDialogRef,
 } from "@angular/material/dialog";
 import { MatButtonModule } from "@angular/material/button";
-import { PluginUpdateInfo } from "../../services/plugin-update.service";
+import { PluginUpdateInfo } from "../../services/plugin-manager.service";
 
 export interface PluginUpdateDialogData {
     plugin_updates: PluginUpdateInfo[];

--- a/ui/src/app/main-view/main-view.component.html
+++ b/ui/src/app/main-view/main-view.component.html
@@ -23,6 +23,10 @@
           <mat-icon>play_arrow</mat-icon>
           Start AI Assistant
         </button>
+        <button mat-raised-button (click)="manage_plugins()" [disabled]="isLoading || !usageDisclaimerAccepted">
+          <mat-icon>extension</mat-icon>
+          Manage Plugins
+        </button>
       }
     </div>
   } @else {

--- a/ui/src/app/main-view/main-view.component.ts
+++ b/ui/src/app/main-view/main-view.component.ts
@@ -18,6 +18,7 @@ import { ChatContainerComponent } from "../components/chat-container/chat-contai
 import { ProjectionsService } from "../services/projections.service";
 import { MetricsService } from "../services/metrics.service.js";
 import { PolicyService } from "../services/policy.service.js";
+import { PluginUpdateService } from "../services/plugin-update.service";
 
 @Component({
     selector: "app-main-view",
@@ -55,6 +56,7 @@ export class MainViewComponent implements OnInit, OnDestroy {
         private projectionsService: ProjectionsService,
         private metricsService: MetricsService,
         private policyService: PolicyService,
+        private plugin_update_service: PluginUpdateService,
     ) {
         this.policyService.usageDisclaimerAccepted$.subscribe(
             (accepted) => {

--- a/ui/src/app/main-view/main-view.component.ts
+++ b/ui/src/app/main-view/main-view.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnDestroy, OnInit, NgZone } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { MatButtonModule } from "@angular/material/button";
 import { MatIconModule } from "@angular/material/icon";
 import { MatProgressBarModule } from "@angular/material/progress-bar";
-import { MatDialogModule } from "@angular/material/dialog";
+import { MatDialog, MatDialogModule } from "@angular/material/dialog";
 import { TauriService } from "../services/tauri.service";
 import { LoggingService } from "../services/logging.service";
 import { LogContainerComponent } from "../components/log-container/log-container.component";
@@ -18,7 +18,8 @@ import { ChatContainerComponent } from "../components/chat-container/chat-contai
 import { ProjectionsService } from "../services/projections.service";
 import { MetricsService } from "../services/metrics.service.js";
 import { PolicyService } from "../services/policy.service.js";
-import { PluginUpdateService } from "../services/plugin-update.service";
+import { PluginManagerService } from "../services/plugin-manager.service";
+import { PluginManagerDialogComponent, PluginManifest } from "../components/plugin-manager-dialog/plugin-manager-dialog.component";
 
 @Component({
     selector: "app-main-view",
@@ -45,8 +46,10 @@ export class MainViewComponent implements OnInit, OnDestroy {
     config: any;
     private configSubscription!: Subscription;
     private inDangerSubscription!: Subscription;
+    private installed_plugin_list_subscription!: Subscription;
     private hasAutoStarted = false;
     public usageDisclaimerAccepted = false;
+    private installed_plugins_list: PluginManifest[] = []
 
     constructor(
         private tauri: TauriService,
@@ -56,7 +59,9 @@ export class MainViewComponent implements OnInit, OnDestroy {
         private projectionsService: ProjectionsService,
         private metricsService: MetricsService,
         private policyService: PolicyService,
-        private plugin_update_service: PluginUpdateService,
+        private plugin_manager_service: PluginManagerService,
+        private ngZone: NgZone,
+        private dialog: MatDialog,
     ) {
         this.policyService.usageDisclaimerAccepted$.subscribe(
             (accepted) => {
@@ -77,6 +82,12 @@ export class MainViewComponent implements OnInit, OnDestroy {
                     this.start();
                     this.hasAutoStarted = true;
                 }
+            },
+        );
+
+        this.installed_plugin_list_subscription = this.plugin_manager_service.installed_plugin_list_message$.subscribe(
+            (installed_plugins_list_message) => {
+                this.installed_plugins_list = installed_plugins_list_message?.plugins || [];
             },
         );
 
@@ -111,6 +122,9 @@ export class MainViewComponent implements OnInit, OnDestroy {
         if (this.inDangerSubscription) {
             this.inDangerSubscription.unsubscribe();
         }
+        if (this.installed_plugin_list_subscription) {
+            this.installed_plugin_list_subscription.unsubscribe();
+        }
     }
 
     acceptUsageDisclaimer() {
@@ -129,6 +143,31 @@ export class MainViewComponent implements OnInit, OnDestroy {
         } catch (error) {
             console.error("Failed to start:", error);
         }
+    }
+
+    async manage_plugins(): Promise<void> {
+        this.ngZone.run(() => {
+            const dialogRef = this.dialog.open(PluginManagerDialogComponent, {
+                width: "400px",
+                data: { installed_plugins: this.installed_plugins_list },
+            });
+
+            dialogRef.afterClosed().subscribe((result) => {
+                if (result !== false) {
+                    this.send_new_plugin_list(result as PluginManifest[]).catch((err) => {
+                        console.error("Failed to send plugin isntall/remove command", err);
+                    });
+                }
+            });
+        });
+    }
+    
+    public async send_new_plugin_list(new_plugin_list: PluginManifest[]): Promise<void> {
+        await this.tauri.send_command({
+            type: "change_installed_plugins",
+            plugins: new_plugin_list,
+            timestamp: new Date().toISOString(),
+        });
     }
 
     async stop(): Promise<void> {

--- a/ui/src/app/main-view/main-view.component.ts
+++ b/ui/src/app/main-view/main-view.component.ts
@@ -148,14 +148,13 @@ export class MainViewComponent implements OnInit, OnDestroy {
     async manage_plugins(): Promise<void> {
         this.ngZone.run(() => {
             const dialogRef = this.dialog.open(PluginManagerDialogComponent, {
-                width: "400px",
                 data: { installed_plugins: this.installed_plugins_list },
             });
 
             dialogRef.afterClosed().subscribe((result) => {
                 if (result !== false) {
                     this.send_new_plugin_list(result as PluginManifest[]).catch((err) => {
-                        console.error("Failed to send plugin isntall/remove command", err);
+                        console.error("Failed to send plugin install/remove command", err);
                     });
                 }
             });

--- a/ui/src/app/services/plugin-manager.service.ts
+++ b/ui/src/app/services/plugin-manager.service.ts
@@ -4,6 +4,7 @@ import { BaseCommand, type BaseMessage, TauriService } from "./tauri.service";
 import { PluginUpdateDialogComponent } from "../components/plugin-update-dialog/plugin-update-dialog.component";
 import { MatDialog } from "@angular/material/dialog";
 import { ConfirmationDialogComponent } from "../components/confirmation-dialog/confirmation-dialog.component";
+import { PluginManifest } from "../components/plugin-manager-dialog/plugin-manager-dialog.component";
 
 export interface PluginUpdateInfo {
     name: string;
@@ -17,29 +18,46 @@ export interface PluginUpdatesAvailableMessage extends BaseMessage {
     updates: PluginUpdateInfo[];
 }
 
-export interface PluginUpdatesInstalledMessage extends BaseMessage {
-    type: "plugin_updates_installed";
+export interface PluginsChangedMessage extends BaseMessage {
+    type: "plugins_changed";
     message: string;
+}
+
+export interface InstalledPluginListMessage extends BaseMessage {
+    type: "installed_plugin_list";
+    plugins: PluginManifest[];
+}
+
+export interface PluginIndexEntry {
+    name: string;
+    latest_manifest_url: string;
 }
 
 @Injectable({
     providedIn: "root",
 })
-export class PluginUpdateService {
+export class PluginManagerService {
+    private installed_plugin_list_message_subject = new BehaviorSubject<
+        InstalledPluginListMessage | null
+    >(null);
+    public installed_plugin_list_message$ = this.installed_plugin_list_message_subject
+        .asObservable();
+
     private plugin_updates_available_message_subject = new BehaviorSubject<
         PluginUpdatesAvailableMessage | null
     >(null);
     public plugin_updates_available_message$ = this.plugin_updates_available_message_subject
         .asObservable();
 
-    private plugin_updates_installed_message_subject = new BehaviorSubject<
-        PluginUpdatesInstalledMessage | null
+    private plugins_changed_message_subject = new BehaviorSubject<
+        PluginsChangedMessage | null
     >(null);
-    public plugin_updates_installed_message$ = this.plugin_updates_installed_message_subject
+    public plugins_changed_message$ = this.plugins_changed_message_subject
         .asObservable();
 
+    private installed_plugin_list_message_subscription?: Subscription;
     private plugin_updates_available_message_subscription?: Subscription;
-    private plugin_updates_installed_message_subscription?: Subscription;
+    private plugins_changed_message_subscription?: Subscription;
 
     constructor(private ngZone: NgZone, private dialog: MatDialog, private tauriService: TauriService) {
         // Subscribe to config messages from the TauriService
@@ -48,17 +66,34 @@ export class PluginUpdateService {
                 message,
             ): message is
                 PluginUpdatesAvailableMessage
-                | PluginUpdatesInstalledMessage =>
+                | InstalledPluginListMessage
+                | PluginsChangedMessage =>
                 message.type === "plugin_updates_available"
-                || message.type === "plugin_updates_installed"
+                || message.type === "installed_plugin_list"
+                || message.type === "plugins_changed"
             ),
         ).subscribe((message) => {
             if (message.type === "plugin_updates_available") {
                 this.plugin_updates_available_message_subject.next(message);
-            } else if (message.type === "plugin_updates_installed") {
-                this.plugin_updates_installed_message_subject.next(message);
+            } else if (message.type === "plugins_changed") {
+                this.plugins_changed_message_subject.next(message);
+            } else if (message.type === "installed_plugin_list") {
+                this.installed_plugin_list_message_subject.next(message);
             }
         });
+        
+        this.installed_plugin_list_message_subscription = this.installed_plugin_list_message$
+        .subscribe(
+            (message) => {
+                if (message) {
+                    console.log("Received list of installed plugins", {
+                        installed_plugins: message.plugins,
+                    });
+                } else {
+                    console.error("Received null list of installed plugins");
+                }
+            },
+        );
 
         this.plugin_updates_available_message_subscription = this.plugin_updates_available_message$
         .subscribe(
@@ -88,20 +123,20 @@ export class PluginUpdateService {
             },
         );
 
-        this.plugin_updates_installed_message_subscription = this.plugin_updates_installed_message$
+        this.plugins_changed_message_subscription = this.plugins_changed_message$
         .subscribe(
-            (plugin_updates_installed_message) => {
-                if (plugin_updates_installed_message) {
-                    console.log("Received plugin updates installed message", {
-                        message: plugin_updates_installed_message.message,
+            (plugins_changed_message) => {
+                if (plugins_changed_message) {
+                    console.log("Received plugins changed message", {
+                        message: plugins_changed_message.message,
                     });
                     
                     this.ngZone.run(() => {
                         const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
                             width: "400px",
                             data: {
-                                title: "Plugin Updates Installed",
-                                message: plugin_updates_installed_message.message,
+                                title: "Plugins changed",
+                                message: plugins_changed_message.message,
                                 confirmButtonText: "Restart COVAS:NEXT",
                                 cancelButtonText: "Later"
                             },
@@ -127,5 +162,18 @@ export class PluginUpdateService {
             type: "update_plugins",
             timestamp: new Date().toISOString(),
         });
+    }
+
+    // Clean up subscriptions when the service is destroyed
+    public ngOnDestroy(): void {
+        if (this.installed_plugin_list_message_subscription) {
+            this.installed_plugin_list_message_subscription.unsubscribe();
+        }
+        if (this.plugin_updates_available_message_subscription) {
+            this.plugin_updates_available_message_subscription.unsubscribe();
+        }
+        if (this.plugins_changed_message_subscription) {
+            this.plugins_changed_message_subscription.unsubscribe();
+        }
     }
 }

--- a/ui/src/app/services/plugin-update.service.ts
+++ b/ui/src/app/services/plugin-update.service.ts
@@ -1,0 +1,131 @@
+import { Injectable, NgZone } from "@angular/core";
+import { BehaviorSubject, filter, Observable, Subscription } from "rxjs";
+import { BaseCommand, type BaseMessage, TauriService } from "./tauri.service";
+import { PluginUpdateDialogComponent } from "../components/plugin-update-dialog/plugin-update-dialog.component";
+import { MatDialog } from "@angular/material/dialog";
+import { ConfirmationDialogComponent } from "../components/confirmation-dialog/confirmation-dialog.component";
+
+export interface PluginUpdateInfo {
+    name: string;
+    version: string;
+    repo: string;
+    release_url: string;
+}
+
+export interface PluginUpdatesAvailableMessage extends BaseMessage {
+    type: "plugin_updates_available";
+    updates: PluginUpdateInfo[];
+}
+
+export interface PluginUpdatesInstalledMessage extends BaseMessage {
+    type: "plugin_updates_installed";
+    message: string;
+}
+
+@Injectable({
+    providedIn: "root",
+})
+export class PluginUpdateService {
+    private plugin_updates_available_message_subject = new BehaviorSubject<
+        PluginUpdatesAvailableMessage | null
+    >(null);
+    public plugin_updates_available_message$ = this.plugin_updates_available_message_subject
+        .asObservable();
+
+    private plugin_updates_installed_message_subject = new BehaviorSubject<
+        PluginUpdatesInstalledMessage | null
+    >(null);
+    public plugin_updates_installed_message$ = this.plugin_updates_installed_message_subject
+        .asObservable();
+
+    private plugin_updates_available_message_subscription?: Subscription;
+    private plugin_updates_installed_message_subscription?: Subscription;
+
+    constructor(private ngZone: NgZone, private dialog: MatDialog, private tauriService: TauriService) {
+        // Subscribe to config messages from the TauriService
+        this.tauriService.output$.pipe(
+            filter((
+                message,
+            ): message is
+                PluginUpdatesAvailableMessage
+                | PluginUpdatesInstalledMessage =>
+                message.type === "plugin_updates_available"
+                || message.type === "plugin_updates_installed"
+            ),
+        ).subscribe((message) => {
+            if (message.type === "plugin_updates_available") {
+                this.plugin_updates_available_message_subject.next(message);
+            } else if (message.type === "plugin_updates_installed") {
+                this.plugin_updates_installed_message_subject.next(message);
+            }
+        });
+
+        this.plugin_updates_available_message_subscription = this.plugin_updates_available_message$
+        .subscribe(
+            (plugin_updates_available_message) => {
+                if (plugin_updates_available_message) {
+                    console.log("Received plugin updates available message", {
+                        updates: plugin_updates_available_message.updates,
+                    });
+                    
+                    this.ngZone.run(() => {
+                        const dialogRef = this.dialog.open(PluginUpdateDialogComponent, {
+                            width: "400px",
+                            data: { plugin_updates: plugin_updates_available_message.updates },
+                        });
+
+                        dialogRef.afterClosed().subscribe((result) => {
+                            if (result) {
+                                this.send_update_plugins().catch((err) => {
+                                    console.error("Failed to send update plugins command", err);
+                                });
+                            }
+                        });
+                    });
+                } else {
+                    console.error("Received null plugin updates available message");
+                }
+            },
+        );
+
+        this.plugin_updates_installed_message_subscription = this.plugin_updates_installed_message$
+        .subscribe(
+            (plugin_updates_installed_message) => {
+                if (plugin_updates_installed_message) {
+                    console.log("Received plugin updates installed message", {
+                        message: plugin_updates_installed_message.message,
+                    });
+                    
+                    this.ngZone.run(() => {
+                        const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+                            width: "400px",
+                            data: {
+                                title: "Plugin Updates Installed",
+                                message: plugin_updates_installed_message.message,
+                                confirmButtonText: "Restart COVAS:NEXT",
+                                cancelButtonText: "Later"
+                            },
+                        });
+
+                        dialogRef.afterClosed().subscribe((result) => {
+                            if (result) {
+                                this.tauriService.restart_app().catch((err) => {
+                                    console.error("Failed to send restart command", err);
+                                });
+                            }
+                        });
+                    });
+                } else {
+                    console.error("Received null plugin updates installed message");
+                }
+            },
+        );
+    }
+    
+    public async send_update_plugins(): Promise<void> {
+        await this.tauriService.send_command({
+            type: "update_plugins",
+            timestamp: new Date().toISOString(),
+        });
+    }
+}

--- a/ui/src/app/services/tauri.service.ts
+++ b/ui/src/app/services/tauri.service.ts
@@ -2,6 +2,7 @@
 import { Injectable, NgZone } from "@angular/core";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
+import { relaunch } from '@tauri-apps/plugin-process';
 import { BehaviorSubject, Observable, ReplaySubject } from "rxjs";
 import { MatDialog } from "@angular/material/dialog";
 import { UpdateDialogComponent } from "../components/update-dialog/update-dialog.component";
@@ -167,6 +168,9 @@ export class TauriService {
             timestamp: new Date().toISOString(),
             index: this.currentIndex++,
         });
+    }
+    public async restart_app(): Promise<void> {
+        await relaunch();
     }
     public async send_command(message: BaseCommand): Promise<void> {
         await invoke("send_json_line", {


### PR DESCRIPTION
This PR aims to implement automatic updates for plugins, as well as a centralized/curated plugin repository to install from, all from inside the app.  

Still missing:  
* [ ] More git providers with release artifacts similar to GitHub.
* [ ] A generic solution for plugin devs who don't use one of the supported providers.
* [ ] Error handling.
* [ ] A way for users to discover and install plugins from inside COVAS:NEXT.
    (See `docs/plugins/plugin_index.json` for WIP idea)


Reminder to myself: Update the cookiecutter template when this is released.  
Also gotta update the plugins, to support auto-updates.