### PR TITLE
fix for ED journal incorrect approachsettlement event at loadgame

### DIFF
--- a/src/lib/Assistant.py
+++ b/src/lib/Assistant.py
@@ -344,6 +344,18 @@ class Assistant:
                                 continue
                         except Exception:
                             pass
+                    # Ignore ApproachSettlement while docked to avoid spurious prompts
+                    is_docked = False
+                    current_status = states.get("CurrentStatus", {})
+                    if isinstance(current_status, dict):
+                        flags = current_status.get("flags", {})
+                        if isinstance(flags, dict):
+                            is_docked = flags.get("Docked", False)
+                    location_state = states.get("Location", {})
+                    if not is_docked and isinstance(location_state, dict):
+                        is_docked = location_state.get("Docked", False)
+                    if is_docked:
+                        continue
 
                 if event.content.get("event") == "ReceiveText":
                     if event.content.get("Channel") not in ['wing', 'voicechat', 'friend', 'player'] and (


### PR DESCRIPTION
The ED journal gets populated with an erroneous ApproachSettlement event just after LoadGame

for example:

{ "timestamp":"2026-01-11T12:20:23Z", "event":"LoadGame", "FID":"F17984", "Commander":"Ryan P Bodfirst", "Horizons":true, "Odyssey":true, "Ship":"PantherMkII", "Ship_Localised":"Panther Clipper Mk II", "ShipID":18, "ShipName":"", "ShipIdent":"", "FuelLevel":128.000000, "FuelCapacity":128.000000, "GameMode":"Solo", "Credits":975778543, "Loan":0, "language":"English/UK", "gameversion":"4.3.0.1", "build":"r322188/r0 " }
{ "timestamp":"2026-01-11T12:20:28Z", "event":"ApproachSettlement", "Name":"Planetary Construction Site: Grover Prospecting Station", "MarketID":4329766659, "StationFaction":{ "Name":"Brewer Corporation" }, "StationGovernment":"$government_Megaconstruction;", "StationGovernment_Localised":"Megaconstruction", "StationServices":[ "dock", "autodock", "commodities", "contacts", "rearm", "refuel", "repair", "flightcontroller", "stationoperations", "stationMenu", "colonisationcontribution" ], "StationEconomy":"$economy_Colony;", "StationEconomy_Localised":"Colony", "StationEconomies":[ { "Name":"$economy_Colony;", "Name_Localised":"Colony", "Proportion":1.000000 } ], "SystemAddress":7269366703553, "BodyID":2, "BodyName":"Hydrae Sector KH-V b2-3 2", "Latitude":-44.456532, "Longitude":139.335785 }

This adds a workaround that ignores it within 10s of LoadGame so COVAS:NEXT does not respond to it.