### PR TITLE
add extra control of npc receivetext events

### DIFF
--- a/docs/30_description.md
+++ b/docs/30_description.md
@@ -122,11 +122,11 @@ We support **every event** in the game that is written to the journal file. You 
    - Scan
 
    #### Trade Events:
-   - Trade
    - AsteroidCracked
    - BuyTradeData
    - CollectCargo
    - EjectCargo
+   - CargoTransfer
    - MarketBuy
    - MarketSell
    - MiningRefined
@@ -179,7 +179,6 @@ We support **every event** in the game that is written to the journal file. You 
    - ShipyardSell
    - ShipyardTransfer
    - ShipyardSwap
-   - StoredModules
    - StoredShips
    - TechnologyBroker
    - ClearImpound
@@ -203,7 +202,6 @@ We support **every event** in the game that is written to the journal file. You 
    - CarrierJumpCancelled
 
    #### Odyssey Events:
-   - Backpack
    - BackpackChange
    - BookDropship
    - BookTaxi
@@ -236,57 +234,173 @@ We support **every event** in the game that is written to the journal file. You 
 
    #### Other Events:
    - AfmuRepairs
+   - ApproachBody
    - ApproachSettlement
+   - BeingInterdicted
+   - Bounty
+   - BountyScanned
+   - BreathableAtmosphereEntered
+   - BreathableAtmosphereExited
+   - BuyExplorationData
+   - CapShipBond
+   - CargoScoopDeployed
+   - CargoScoopRetracted
    - ChangeCrewRole
+   - ClearSavedGame
    - CockpitBreached
+   - CombatDiscovered
+   - CombatEntered
+   - CombatExited
    - CommitCrime
-   - Continued
+   - CrimeVictim
    - CrewLaunchFighter
    - CrewMemberJoins
    - CrewMemberQuits
    - CrewMemberRoleChange
-   - CrimeVictim
    - DatalinkScan
    - DatalinkVoucher
    - DataScanned
+   - Died
    - DockFighter
    - DockSRV
+   - Docked
+   - DockingCanceled
+   - DockingComputerDeactivated
+   - DockingComputerDocking
+   - DockingComputerUndocking
+   - DockingDenied
+   - DockingGranted
+   - DockingRequested
+   - DockingTimeout
    - EndCrewSession
+   - EscapeInterdiction
+   - FsdCharging
+   - FsdMassLockEscaped
+   - FsdMassLocked
+   - FSDJump
+   - FSDTarget
+   - FSSAllBodiesFound
+   - FSSBodySignals
+   - FSSDiscoveryScan
+   - FactionKillBond
+   - FetchRemoteModuleCompleted
+   - FighterDestroyed
    - FighterRebuilt
-   - FuelScoop
+   - FirstPlayerSystemDiscovered
+   - FleetCarrierDiscovered
+   - FlightAssistOff
+   - FlightAssistOn
    - Friends
+   - FuelScoop
+   - FuelScoopEnded
+   - FuelScoopStarted
+   - GenericDiscovered
+   - GlideModeEntered
+   - GlideModeExited
+   - HardpointsDeployed
+   - HardpointsRetracted
+   - HeatDamage
+   - HeatWarning
+   - HighGravityWarning
+   - HudSwitchedToAnalysisMode
+   - HudSwitchedToCombatMode
+   - HullDamage
+   - Idle
+   - InDanger
+   - InstallationDiscovered
+   - Interdicted
+   - Interdiction
    - JetConeBoost
    - JetConeDamage
    - JoinACrew
    - KickCrewMember
+   - LandingGearDown
+   - LandingGearUp
    - LaunchDrone
    - LaunchFighter
    - LaunchSRV
+   - RememberLimpets
+   - LeaveBody
+   - LegalStateChanged
+   - Liftoff
+   - LightsOff
+   - LightsOn
+   - LoadGame
+   - LowFuelWarning
+   - LowFuelWarningCleared
+   - LowHealthWarning
+   - LowHealthWarningCleared
+   - LowOxygenWarning
+   - LowOxygenWarningCleared
+   - MaterialCollected
+   - MaterialDiscarded
+   - MaterialDiscovered
+   - MegashipDiscovered
    - ModuleInfo
-   - NpcCrewPaidWage
+   - MultiSellExplorationData
+   - NavBeaconDiscovered
+   - NavBeaconScan
+   - NavRoute
+   - NavRouteClear
+   - NewCommander
+   - NightVisionOff
+   - NightVisionOn
+   - NoScoopableStars
    - NpcCrewRank
+   - OutofDanger
+   - OutpostDiscovered
+   - PVPKill
+   - Powerplay
    - Promotion
    - ProspectedAsteroid
    - QuitACrew
    - RebootRepair
    - ReceiveText
+     NPC types configurable: Station, Police, Docking chatter, Military, Cruise liner, Commuter, AX, Trader, Pirate (includes pirate hunter), Powers, Miner, Explorer, Smuggler, Passenger liner, Escort, Hitman, Propagandist, Rescuer, Convoy, Damaged escape pod, Refugee flotilla, Protester, Other catch-all
    - RepairDrone
-   - ReservoirReplenished
    - Resurrect
+   - ResourceExtractionDiscovered
+   - SAAScanComplete
+   - SAASignalsFound
    - Scanned
+   - ScanBaryCentre
+   - Screenshot
    - SelfDestruct
+   - SellExplorationData
    - SendText
    - Shutdown
+   - ShieldState
+   - ShipTargeted
+   - ShipyardTransferCompleted
+   - SilentRunningOff
+   - SilentRunningOn
+   - SRVDestroyed
+   - SrvDriveAssistOff
+   - SrvDriveAssistOn
+   - SrvHandbrakeOff
+   - SrvHandbrakeOn
+   - SrvTurretViewConnected
+   - SrvTurretViewDisconnected
+   - StartJump
+   - StationDiscovered
+   - SupercruiseDestinationDrop
+   - SupercruiseEntry
+   - SupercruiseExit
    - Synthesis
    - SystemsShutdown
+   - Touchdown
+   - TouristBeaconDiscovered
+   - UnderAttack
+   - Undocked
+   - UnknownSignalDiscovered
    - USSDrop
    - VehicleSwitch
+   - WeaponSelected
    - WingAdd
    - WingInvite
    - WingJoin
    - WingLeave
-   - CargoTransfer
-   - SupercruiseDestinationDrop
+
 
 These event-driven interactions are designed to enhance safety, decision-making, and overall user engagement throughout the journey in Elite Dangerous.
 

--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -375,12 +375,43 @@ class Character(TypedDict, total=False):
     react_to_text_starsystem_var: bool
     react_to_text_npc_var: bool
     react_to_text_squadron_var: bool
+    react_to_text_tokens: list[str]
     react_to_material: str
     react_to_danger_mining_var: bool
     react_to_danger_onfoot_var: bool
     react_to_danger_supercruise_var: bool
     idle_timeout_var: int
     disabled_game_events: list[str]
+
+# ReceiveText $Name families available for filtering (condensed)
+RECEIVE_TEXT_TOKEN_CHOICES: list[str] = [
+    "$POLICE;",
+    "$DOCKINGCHATTER;",
+    "$STATION;",
+    "$MILITARY;",
+    "$CRUISELINER;",
+    "$COMMUTER;",
+    "$AX;",
+    "$TRADER;",
+    "$PIRATE;",
+    "$POWERS;",
+    "$MINER;",
+    "$EXPLORER;",
+    "$SMUGGLER;",
+    "$PASSENGERLINER;",
+    "$ESCORT;",
+    "$HITMAN;",
+    "$PROPAGANDIST;",
+    "$RESCUER;",
+    "$CONVOY;",
+    "$DAMAGEDESCAPEPOD;",
+    "$REFUGEEFLOTILLAWAR;",
+    "$PROTESTER;",
+    "$OTHER;",  # fallback for unknown tokens
+]
+
+# Default to all known families
+RECEIVE_TEXT_TOKEN_DEFAULTS: list[str] = RECEIVE_TEXT_TOKEN_CHOICES.copy()
 
 
 class Config(TypedDict):
@@ -521,6 +552,7 @@ def migrate(data: dict) -> dict:
                         "react_to_text_starsystem_var": data.get('react_to_text_starsystem_var', True),
                         "react_to_text_npc_var": data.get('react_to_text_npc_var', False),
                         "react_to_text_squadron_var": data.get('react_to_text_squadron_var', True),
+                        "react_to_text_tokens": data.get('react_to_text_tokens', RECEIVE_TEXT_TOKEN_DEFAULTS.copy()),
                         "react_to_material": data.get('react_to_material', 'opal, diamond, alexandrite'),
                         "react_to_danger_mining_var": data.get('react_to_danger_mining_var', False),
                         "react_to_danger_onfoot_var": data.get('react_to_danger_onfoot_var', False),
@@ -561,6 +593,7 @@ def migrate(data: dict) -> dict:
                 "react_to_text_starsystem_var": data.get('react_to_text_starsystem_var', True),
                 "react_to_text_npc_var": data.get('react_to_text_npc_var', False),
                 "react_to_text_squadron_var": data.get('react_to_text_squadron_var', True),
+                "react_to_text_tokens": data.get('react_to_text_tokens', RECEIVE_TEXT_TOKEN_DEFAULTS.copy()),
                 "react_to_material": data.get('react_to_material', 'opal, diamond, alexandrite'),
                 "react_to_danger_mining_var": data.get('react_to_danger_mining_var', False),
                 "react_to_danger_onfoot_var": data.get('react_to_danger_onfoot_var', False),
@@ -806,6 +839,7 @@ def getDefaultCharacter(config: Config) -> Character:
         "react_to_text_starsystem_var": True,
         "react_to_text_npc_var": False,
         "react_to_text_squadron_var": True,
+        "react_to_text_tokens": RECEIVE_TEXT_TOKEN_DEFAULTS.copy(),
         "react_to_material": 'opal, diamond, alexandrite',
         "react_to_danger_mining_var": False,
         "react_to_danger_onfoot_var": False,

--- a/ui/src/app/components/character-settings/character-settings.component.html
+++ b/ui/src/app/components/character-settings/character-settings.component.html
@@ -625,6 +625,21 @@
                                         React to NPC text
                                     </mat-slide-toggle>
                                     </div>
+
+                                <div class="event-suboption">
+                                    <mat-form-field appearance="outline" class="full-width">
+                                        <mat-label>React to these NPC types</mat-label>
+                                        <mat-select multiple
+                                            [disabled]="!isNpcReactEnabled()"
+                                            [ngModel]="getCharacterProperty('react_to_text_tokens', [])"
+                                            (ngModelChange)="setCharacterProperty('react_to_text_tokens', $event)">
+                                            <mat-option *ngFor="let opt of receiveTextTokenOptions" [value]="opt.value"
+                                                [matTooltip]="opt.hint" matTooltipPosition="right">
+                                                {{opt.label}}
+                                            </mat-option>
+                                        </mat-select>
+                                    </mat-form-field>
+                                </div>
                                 }
 
                                 @if (e.key === "Idle") {

--- a/ui/src/app/components/character-settings/character-settings.component.ts
+++ b/ui/src/app/components/character-settings/character-settings.component.ts
@@ -105,6 +105,35 @@ export class CharacterSettingsComponent {
     voiceInstructionSupportedModels: string[] = this.characterService.voiceInstructionSupportedModels;
 
     gameEventCategories = GameEventCategories;
+    receiveTextTokenOptions = [
+        { value: "$STATION;", label: "Station", hint: "Station/system ATC (e.g., docking granted/denied)" },
+        { value: "$POLICE;", label: "Police", hint: "Authority patrols and landing chatter" },
+        { value: "$DOCKINGCHATTER;", label: "Docking chatter", hint: "Non-critical pad/landing banter" },
+        { value: "$MILITARY;", label: "Military", hint: "System defense or patrol calls" },
+        { value: "$CRUISELINER;", label: "Cruise liner", hint: "Tourist ship announcements" },
+        { value: "$COMMUTER;", label: "Commuter", hint: "Civilian commuter remarks" },
+        { value: "$AX;", label: "AX/Anti-xeno", hint: "Anti-xeno patrol chatter" },
+        { value: "$TRADER;", label: "Trader", hint: "Merchant and hauler chatter" },
+        { value: "$PIRATE;", label: "Pirate", hint: "Piracy/hostile scans (includes pirate hunter)" },
+        { value: "$POWERS;", label: "Powers/Powerplay", hint: "Power agents/enforcers/security" },
+        { value: "$MINER;", label: "Miner", hint: "Prospector/miner chatter" },
+        { value: "$EXPLORER;", label: "Explorer", hint: "Explorer pass-through comments" },
+        { value: "$SMUGGLER;", label: "Smuggler", hint: "Smuggler threats/remarks" },
+        { value: "$PASSENGERLINER;", label: "Passenger liner", hint: "Passenger service announcements" },
+        { value: "$ESCORT;", label: "Escort", hint: "Escort attack/engagement calls" },
+        { value: "$HITMAN;", label: "Hitman/assassin", hint: "Contract killer threats/engagements" },
+        { value: "$PROPAGANDIST;", label: "Propagandist", hint: "Propaganda and rallying messages" },
+        { value: "$RESCUER;", label: "Rescuer/SAR", hint: "Search and rescue transfer calls" },
+        { value: "$CONVOY;", label: "Convoy (wedding/funeral)", hint: "Ceremonial convoy chatter" },
+        { value: "$DAMAGEDESCAPEPOD;", label: "Damaged escape pod", hint: "Threats/demands about escape pods" },
+        { value: "$REFUGEEFLOTILLAWAR;", label: "Refugee flotilla", hint: "War refugee flotilla chatter" },
+        { value: "$PROTESTER;", label: "Protester", hint: "Protest slogans/objections" },
+        { value: "$OTHER;", label: "Other (unknown/uncategorized)", hint: "Any unrecognized token" },
+    ];
+
+    public isNpcReactEnabled(): boolean {
+        return this.getCharacterProperty("react_to_text_npc_var", false);
+    }
 
     edgeTtsVoices = [
         // English voices - US

--- a/ui/src/app/services/character.service.ts
+++ b/ui/src/app/services/character.service.ts
@@ -39,6 +39,7 @@ export interface Character {
     react_to_text_starsystem_var: boolean;
     react_to_text_npc_var: boolean;
     react_to_text_squadron_var: boolean;
+    react_to_text_tokens: string[];
     react_to_material: string;
     idle_timeout_var: number;
     react_to_danger_mining_var: boolean;


### PR DESCRIPTION
This adds support for finer grained reactions to npc receive text events by npc type (which is available in the receivetext "Message" key)

These include:

Station, Police, Docking chatter, Military, Cruise liner, Commuter, AX, Trader, Pirate (includes pirate hunter), Powers, Miner, Explorer, Smuggler, Passenger liner, Escort, Hitman, Propagandist, Rescuer, Convoy, Damaged escape pod, Refugee flotilla, Protester, Other catch-all

This allows the player to personalise what they want to react to rather than all or nothing.

Updated the docs whilst I was at it with all the currently supported events as it was missing quite a few.