### PR TITLE
Feat/in docking range

### DIFF
--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -88,6 +88,7 @@ game_events = {
     'SupercruiseEntry': True,
     'SupercruiseExit': True,
     'ApproachSettlement': True,
+    'InDockingRange': True,
     'Docked': True,
     'Undocked': True,
     'DockingCanceled': False,

--- a/src/lib/Projections.py
+++ b/src/lib/Projections.py
@@ -3356,6 +3356,7 @@ def registerProjections(
     event_manager.register_projection(InCombat())
     event_manager.register_projection(Wing())
     event_manager.register_projection(FSSSignals())
+    event_manager.register_projection(InDockingRange())
     event_manager.register_projection(Idle(idle_timeout))
     event_manager.register_projection(StoredModules())
     event_manager.register_projection(StoredShips())

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -2255,6 +2255,9 @@ class PromptGenerator:
         if event_name == 'Idle':
             return f"Your conversation with {self.commander_name} hasgone silent for a while. Get their attention by making a joke fitting to the current situation or self-reflecting on the recent past.",
 
+        if event_name == "InDockingRange":
+            return f"{self.commander_name}'s ship is now close enough to the station to make a docking request."
+
         if event_name == "DockingComputerDocking":
             return f"{self.commander_name}'s ship has initiated automated docking computer"
 

--- a/ui/src/app/components/character-settings/game-event-categories.ts
+++ b/ui/src/app/components/character-settings/game-event-categories.ts
@@ -69,6 +69,7 @@ export const GameEventCategories: Record<string, string[]> = {
         "SupercruiseEntry",
         "SupercruiseExit",
         "ApproachSettlement",
+        "InDockingRange",
         "GlideModeExited",
         "GlideModeEntered",
         "Docked",

--- a/ui/src/app/components/character-settings/game-event-tooltips.ts
+++ b/ui/src/app/components/character-settings/game-event-tooltips.ts
@@ -71,6 +71,7 @@ export const GameEventTooltips: Record<string, string> = {
   "SupercruiseEntry": "COVAS:NEXT will react when your ship enters supercruise mode for high-speed travel within a system.",
   "SupercruiseExit": "COVAS:NEXT will react when you drop out of supercruise. Telling you about the type of location you've arrived at.",
   "ApproachSettlement": "COVAS:NEXT will react when you approach a planetary settlement. Telling you about proximity to surface installations.",
+  "InDockingRange": "COVAS:NEXT will react when the ship is in docking range",
   "GlideModeExited": "COVAS:NEXT will react when your ship exits glide mode near a planet’s surface.",
   "GlideModeEntered": "COVAS:NEXT will react when your ship enters a planet’s atmosphere after supercruise.",
   "Docked": "COVAS:NEXT will react when your ship docks successfully at a station or planetary base.",


### PR DESCRIPTION
This adds a projection to add in indockingrange event
It works by checking receivetext and in cases where that isn't sent (for example on colonisation construction stations) it uses FSDmasslock.

Tested in multiple sessions on different port types using OpenAI.