### PR TITLE
feat: add latency and cache usage analytics

### DIFF
--- a/src/lib/Assistant.py
+++ b/src/lib/Assistant.py
@@ -8,7 +8,15 @@ from time import time
 
 from pydantic import BaseModel
 from .Models import LLMModel, EmbeddingModel, LLMError
-from .Logger import log, observe, show_chat_message, PromptUsageStats, log_llm_usage
+from .Logger import (
+    CacheUsageStats,
+    PromptUsageStats,
+    log,
+    log_action_cache_usage,
+    log_llm_usage,
+    observe,
+    show_chat_message,
+)
 from .Config import (
     Config,
     CharacterTTSPostprocessingConfig,
@@ -773,6 +781,7 @@ class Assistant:
             if action_input_desc:
                 self.tts.say(
                     action_input_desc,
+                    context="assistant_acting",
                     postprocessing_layers=self._get_tts_postprocessing_layers(projected_states),
                 )
             action_result = self.action_manager.runAction(action, projected_states)
@@ -878,6 +887,12 @@ class Assistant:
                 #log('info', 'predicted_actions', predicted_actions)
                 response_text = None
                 response_actions = predicted_actions
+                log_action_cache_usage(
+                    "assistant",
+                    provider=getattr(self.llmModel, "provider_name", None),
+                    model_name=getattr(self.llmModel, "model_name", None),
+                    cache_usage=CacheUsageStats(llm_calls_saved=1),
+                )
             else:
                 start_time = time()
                     
@@ -901,6 +916,7 @@ class Assistant:
                 self.event_manager.add_assistant_speaking()
                 self.tts.say(
                     response_text,
+                    context="assistant",
                     postprocessing_layers=self._get_tts_postprocessing_layers(projected_states),
                 )
                 self.event_manager.add_conversation_event('assistant', response_text, reasons=reasons, processed_at=max_conversation_processed)
@@ -1031,6 +1047,7 @@ class Assistant:
         args = {'query': query}
         self.tts.say(
             f"Searching: {query}",
+            context="web_search",
             postprocessing_layers=self._get_tts_postprocessing_layers(projected_states),
         )
         

--- a/src/lib/Logger.py
+++ b/src/lib/Logger.py
@@ -301,6 +301,31 @@ class PromptUsageStats:
 
 
 @dataclass
+class LatencyUsageStats:
+    response_ms: float | None = None
+    time_to_first_token_ms: float | None = None
+    time_to_first_byte_ms: float | None = None
+
+
+@dataclass
+class AudioUsageStats:
+    input_audio_duration_ms: float | None = None
+    output_audio_duration_ms: float | None = None
+
+
+@dataclass
+class TextUsageStats:
+    input_chars: int | None = None
+    output_chars: int | None = None
+
+
+@dataclass
+class CacheUsageStats:
+    llm_calls_saved: int = 0
+    llm_calls_added: int = 0
+
+
+@dataclass
 class ModelUsageStats:
     """Token-level API usage as reported by the model provider."""
 
@@ -311,6 +336,72 @@ class ModelUsageStats:
     reasoning_tokens: int | None = None
     provider: str | None = None
     model_name: str | None = None
+    response_ms: float | None = None
+    time_to_first_token_ms: float | None = None
+    output_chars: int | None = None
+
+
+def _to_usage_payload_dict(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+
+    data = vars(value).copy()
+    return {key: item for key, item in data.items() if item is not None}
+
+
+def _persist_and_send_usage(
+    *,
+    usage_kind: str,
+    message: dict[str, Any],
+) -> None:
+    try:
+        from .Database import ModelUsageStore
+
+        ModelUsageStore().insert(
+            timestamp=message["timestamp"],
+            usage_kind=usage_kind,
+            payload=message,
+        )
+    except Exception as exc:
+        log("error", "Failed to persist model usage:", exc)
+
+    send_message(message)
+
+
+def _build_usage_message(
+    *,
+    message_type: str,
+    timestamp: str,
+    context: str,
+    provider: str | None,
+    model_name: str | None,
+    model_usage: dict[str, Any] | None = None,
+    prompt_usage: dict[str, Any] | None = None,
+    latency_usage: dict[str, Any] | None = None,
+    audio_usage: dict[str, Any] | None = None,
+    text_usage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "type": message_type,
+        "schema_version": 2,
+        "timestamp": timestamp,
+        "context": context,
+        "provider": provider,
+        "model_name": model_name,
+    }
+
+    if model_usage is not None:
+        message["model_usage"] = model_usage
+    if prompt_usage is not None:
+        message["prompt_usage"] = prompt_usage
+    if latency_usage is not None:
+        message["latency_usage"] = latency_usage
+    if audio_usage is not None:
+        message["audio_usage"] = audio_usage
+    if text_usage is not None:
+        message["text_usage"] = text_usage
+
+    return message
 
 
 def log_llm_usage(
@@ -318,33 +409,118 @@ def log_llm_usage(
     model_usage: ModelUsageStats,
     prompt_usage: PromptUsageStats,
     llm_model: Any | None = None,
+    response_text: str | None = None,
 ) -> None:
     timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     provider = getattr(llm_model, "provider_name", None) or model_usage.provider
     model_name = getattr(llm_model, "model_name", None) or model_usage.model_name
-    model_usage_data = vars(model_usage).copy()
+    model_usage_data = {
+        "input_tokens": model_usage.input_tokens,
+        "output_tokens": model_usage.output_tokens,
+        "total_tokens": model_usage.total_tokens,
+        "cached_tokens": model_usage.cached_tokens,
+        "reasoning_tokens": model_usage.reasoning_tokens,
+    }
     if provider is not None:
         model_usage_data["provider"] = provider
     if model_name is not None:
         model_usage_data["model_name"] = model_name
     prompt_usage_data = vars(prompt_usage).copy()
     prompt_usage_data["total_prompt_chars"] = prompt_usage.compute_total()
+    latency_usage = _to_usage_payload_dict(
+        LatencyUsageStats(
+            response_ms=model_usage.response_ms,
+            time_to_first_token_ms=model_usage.time_to_first_token_ms,
+        ),
+    )
+    text_usage = _to_usage_payload_dict(
+        TextUsageStats(
+            output_chars=(
+                len(response_text)
+                if response_text is not None
+                else model_usage.output_chars
+            ),
+        ),
+    )
 
-    message = {
-        "type": "llm_usage",
-        "timestamp": timestamp,
-        "context": context,
-        "provider": provider,
-        "model_name": model_name,
-        "model_usage": model_usage_data,
-        "prompt_usage": prompt_usage_data,
-    }
+    message = _build_usage_message(
+        message_type="llm_usage",
+        timestamp=timestamp,
+        context=context,
+        provider=provider,
+        model_name=model_name,
+        model_usage=model_usage_data,
+        prompt_usage=prompt_usage_data,
+        latency_usage=latency_usage,
+        text_usage=text_usage,
+    )
 
-    try:
-        from .Database import ModelUsageStore
+    _persist_and_send_usage(usage_kind="llm", message=message)
 
-        ModelUsageStore().insert(timestamp=timestamp, usage_kind="llm", payload=message)
-    except Exception as exc:
-        log("error", "Failed to persist model usage:", exc)
 
-    send_message(message)
+def log_stt_usage(
+    context: str,
+    *,
+    provider: str | None,
+    model_name: str | None,
+    latency_usage: LatencyUsageStats | None = None,
+    audio_usage: AudioUsageStats | None = None,
+    text_usage: TextUsageStats | None = None,
+) -> None:
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    message = _build_usage_message(
+        message_type="stt_usage",
+        timestamp=timestamp,
+        context=context,
+        provider=provider,
+        model_name=model_name,
+        latency_usage=_to_usage_payload_dict(latency_usage),
+        audio_usage=_to_usage_payload_dict(audio_usage),
+        text_usage=_to_usage_payload_dict(text_usage),
+    )
+
+    _persist_and_send_usage(usage_kind="stt", message=message)
+
+
+def log_tts_usage(
+    context: str,
+    *,
+    provider: str | None,
+    model_name: str | None,
+    latency_usage: LatencyUsageStats | None = None,
+    audio_usage: AudioUsageStats | None = None,
+    text_usage: TextUsageStats | None = None,
+) -> None:
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    message = _build_usage_message(
+        message_type="tts_usage",
+        timestamp=timestamp,
+        context=context,
+        provider=provider,
+        model_name=model_name,
+        latency_usage=_to_usage_payload_dict(latency_usage),
+        audio_usage=_to_usage_payload_dict(audio_usage),
+        text_usage=_to_usage_payload_dict(text_usage),
+    )
+
+    _persist_and_send_usage(usage_kind="tts", message=message)
+
+
+def log_action_cache_usage(
+    context: str,
+    *,
+    provider: str | None,
+    model_name: str | None,
+    cache_usage: CacheUsageStats,
+) -> None:
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    message = _build_usage_message(
+        message_type="action_cache_usage",
+        timestamp=timestamp,
+        context=context,
+        provider=provider,
+        model_name=model_name,
+    )
+    message["cache_usage"] = _to_usage_payload_dict(cache_usage) or {}
+
+    _persist_and_send_usage(usage_kind="llm", message=message)

--- a/src/lib/Logger.py
+++ b/src/lib/Logger.py
@@ -349,6 +349,13 @@ def _to_usage_payload_dict(value: Any) -> dict[str, Any] | None:
     return {key: item for key, item in data.items() if item is not None}
 
 
+def _normalize_optional_string(value: Any) -> str | None:
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized if normalized else None
+    return None
+
+
 def _persist_and_send_usage(
     *,
     usage_kind: str,
@@ -380,14 +387,14 @@ def _build_usage_message(
     latency_usage: dict[str, Any] | None = None,
     audio_usage: dict[str, Any] | None = None,
     text_usage: dict[str, Any] | None = None,
-) -> dict[str, Any]:
+    ) -> dict[str, Any]:
     message: dict[str, Any] = {
         "type": message_type,
         "schema_version": 2,
         "timestamp": timestamp,
         "context": context,
-        "provider": provider,
-        "model_name": model_name,
+        "provider": _normalize_optional_string(provider),
+        "model_name": _normalize_optional_string(model_name),
     }
 
     if model_usage is not None:
@@ -412,8 +419,12 @@ def log_llm_usage(
     response_text: str | None = None,
 ) -> None:
     timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    provider = getattr(llm_model, "provider_name", None) or model_usage.provider
-    model_name = getattr(llm_model, "model_name", None) or model_usage.model_name
+    provider = _normalize_optional_string(getattr(llm_model, "provider_name", None))
+    if provider is None:
+        provider = _normalize_optional_string(model_usage.provider)
+    model_name = _normalize_optional_string(getattr(llm_model, "model_name", None))
+    if model_name is None:
+        model_name = _normalize_optional_string(model_usage.model_name)
     model_usage_data = {
         "input_tokens": model_usage.input_tokens,
         "output_tokens": model_usage.output_tokens,

--- a/src/lib/Models.py
+++ b/src/lib/Models.py
@@ -52,6 +52,116 @@ def _model_dump_compatible(value: Any) -> Any:
         return value.dict()
     return value
 
+
+def _infer_schema_type(schema: dict[str, Any]) -> str | None:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str) and schema_type:
+        return schema_type
+
+    if isinstance(schema_type, list):
+        for item in schema_type:
+            if isinstance(item, str) and item and item != "null":
+                return item
+
+    for union_key in ("anyOf", "oneOf", "allOf"):
+        options = schema.get(union_key)
+        if not isinstance(options, list):
+            continue
+
+        for option in options:
+            option_schema = _model_dump_compatible(option)
+            if not isinstance(option_schema, dict):
+                continue
+
+            inferred = _infer_schema_type(option_schema)
+            if inferred and inferred != "null":
+                return inferred
+
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        return "object"
+
+    if "items" in schema:
+        return "array"
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list):
+        for value in enum_values:
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                return "boolean"
+            if isinstance(value, int) and not isinstance(value, bool):
+                return "integer"
+            if isinstance(value, float):
+                return "number"
+            if isinstance(value, str):
+                return "string"
+
+    default_value = schema.get("default")
+    if default_value is not None:
+        if isinstance(default_value, bool):
+            return "boolean"
+        if isinstance(default_value, int) and not isinstance(default_value, bool):
+            return "integer"
+        if isinstance(default_value, float):
+            return "number"
+        if isinstance(default_value, str):
+            return "string"
+        if isinstance(default_value, list):
+            return "array"
+        if isinstance(default_value, dict):
+            return "object"
+
+    if any(key in schema for key in ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum")):
+        return "number"
+
+    return None
+
+
+def _normalize_tool_schema(schema: Any) -> Any:
+    schema = _model_dump_compatible(schema)
+
+    if isinstance(schema, list):
+        return [_normalize_tool_schema(item) for item in schema]
+
+    if not isinstance(schema, dict):
+        return schema
+
+    normalized = {key: _normalize_tool_schema(value) for key, value in schema.items()}
+
+    inferred_type = _infer_schema_type(normalized)
+    if inferred_type:
+        normalized["type"] = inferred_type
+
+    properties = normalized.get("properties")
+    if isinstance(properties, dict):
+        for value in properties.values():
+            if isinstance(value, dict):
+                value.setdefault("description", "")
+                child_type = _infer_schema_type(value)
+                if child_type:
+                    value["type"] = child_type
+
+    items = normalized.get("items")
+    if isinstance(items, dict):
+        items.setdefault("description", "")
+        item_type = _infer_schema_type(items)
+        if item_type:
+            items["type"] = item_type
+
+    return normalized
+
+
+def _normalize_tools_for_chat_template(tools: list[dict]) -> list[dict[str, Any]]:
+    normalized_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        normalized_tool = _model_dump_compatible(tool)
+        if not isinstance(normalized_tool, dict):
+            continue
+        normalized_tools.append(_normalize_tool_schema(normalized_tool))
+    return normalized_tools
+
 def _get_reasoning_tokens(usage: Any) -> int | None:
     for details_name in ("output_tokens_details", "completion_tokens_details"):
         details = getattr(usage, details_name, None)
@@ -102,6 +212,7 @@ class OpenAILLMModel(LLMModel):
         self.extra_headers = extra_headers or {}
 
     def generate(self, messages: List[dict], tools: Optional[List[dict]] = None, tool_choice: Optional[Any] = None) -> tuple[str | None, List[Any] | None, ModelUsageStats]:
+        started_at = time()
         kwargs = {}
         # Special handling for specific models or providers if needed
         if self.model_name in ['gpt-5', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5.1']:
@@ -134,7 +245,10 @@ class OpenAILLMModel(LLMModel):
             **kwargs
         }
         if tools:
-            params["tools"] = tools
+            # LM Studio's embedded FunctionGemma template expects every schema node
+            # to have a direct scalar `type`. Normalize tool schemas defensively so
+            # optional or partially-specified fields do not crash prompt rendering.
+            params["tools"] = _normalize_tools_for_chat_template(tools)
             if tool_choice:
                 params["tool_choice"] = tool_choice
         
@@ -169,13 +283,33 @@ class OpenAILLMModel(LLMModel):
         
         if not completion.choices:
             log("debug", "LLM completion has no choices:", completion)
-            return (None, None, ModelUsageStats(provider=self.provider_name, model_name=self.model_name)) # Treated as "..."
+            return (
+                None,
+                None,
+                ModelUsageStats(
+                    provider=self.provider_name,
+                    model_name=self.model_name,
+                    response_ms=(time() - started_at) * 1000,
+                ),
+            ) # Treated as "..."
 
         if not hasattr(completion.choices[0], 'message') or not completion.choices[0].message:
             log("debug", "LLM completion choice has no message:", completion)
-            return (None, None, ModelUsageStats(provider=self.provider_name, model_name=self.model_name)) # Treated as "..."
-        
-        usage_metadata = ModelUsageStats(provider=self.provider_name, model_name=self.model_name)
+            return (
+                None,
+                None,
+                ModelUsageStats(
+                    provider=self.provider_name,
+                    model_name=self.model_name,
+                    response_ms=(time() - started_at) * 1000,
+                ),
+            ) # Treated as "..."
+
+        usage_metadata = ModelUsageStats(
+            provider=self.provider_name,
+            model_name=self.model_name,
+            response_ms=(time() - started_at) * 1000,
+        )
         if hasattr(completion, 'usage') and completion.usage:
             log("debug", f'LLM completion usage', completion.usage)
             usage_metadata.input_tokens = completion.usage.prompt_tokens
@@ -201,6 +335,9 @@ class OpenAILLMModel(LLMModel):
 
         if response_text is None and response_actions is None:
              return (None, None, usage_metadata)
+
+        if response_text is not None:
+            usage_metadata.output_chars = len(response_text)
 
         return (response_text, response_actions, usage_metadata)
 
@@ -361,7 +498,7 @@ class OpenAIResponsesLLMModel(LLMModel):
     def _convert_tools(self, tools: List[dict]) -> list[dict[str, Any]]:
         converted_tools: list[dict[str, Any]] = []
 
-        for raw_tool in tools:
+        for raw_tool in _normalize_tools_for_chat_template(tools):
             tool = _model_dump_compatible(raw_tool)
             if not isinstance(tool, dict):
                 continue
@@ -420,6 +557,7 @@ class OpenAIResponsesLLMModel(LLMModel):
         return tool_calls or None
 
     def generate(self, messages: List[dict], tools: Optional[List[dict]] = None, tool_choice: Optional[Any] = None) -> tuple[str | None, List[Any] | None, ModelUsageStats]:
+        started_at = time()
         params: dict[str, Any] = {
             "model": self.model_name,
             "input": self._convert_messages(messages),
@@ -463,7 +601,11 @@ class OpenAIResponsesLLMModel(LLMModel):
             log("debug", "LLM response error:", response)
             raise LLMError("LLM error: No valid response received")
 
-        usage_metadata = ModelUsageStats(provider=self.provider_name, model_name=self.model_name)
+        usage_metadata = ModelUsageStats(
+            provider=self.provider_name,
+            model_name=self.model_name,
+            response_ms=(time() - started_at) * 1000,
+        )
         if hasattr(response, 'usage') and response.usage:
             log("debug", "LLM response usage", response.usage)
             usage_metadata.input_tokens = getattr(response.usage, "input_tokens", 0)
@@ -478,6 +620,9 @@ class OpenAIResponsesLLMModel(LLMModel):
 
         if response_text is None and response_actions is None:
             return (None, None, usage_metadata)
+
+        if response_text is not None:
+            usage_metadata.output_chars = len(response_text)
 
         return (response_text, response_actions, usage_metadata)
 
@@ -509,17 +654,19 @@ class OpenAIEmbeddingModel(EmbeddingModel):
 
 class STTModel(ABC):
     model_name: str
+    provider_name: str | None
 
-    def __init__(self, model_name: str):
+    def __init__(self, model_name: str, provider_name: str | None = None):
         self.model_name = model_name
+        self.provider_name = provider_name
 
     @abstractmethod
     def transcribe(self, audio: sr.AudioData) -> str:
         pass
 
 class OpenAISTTModel(STTModel):
-    def __init__(self, base_url: str, api_key: str, model_name: str, language: Optional[str] = None, prompt: Optional[str] = None):
-        super().__init__(model_name)
+    def __init__(self, base_url: str, api_key: str, model_name: str, language: Optional[str] = None, prompt: Optional[str] = None, provider_name: str | None = None):
+        super().__init__(model_name, provider_name=provider_name)
         self.client = OpenAI(base_url=base_url, api_key=api_key)
         self.language = language
         self.prompt = prompt
@@ -563,8 +710,8 @@ class OpenAISTTModel(STTModel):
         return text
 
 class OpenAIMultiModalSTTModel(STTModel):
-    def __init__(self, base_url: str, api_key: str, model_name: str, prompt: Optional[str] = None):
-        super().__init__(model_name)
+    def __init__(self, base_url: str, api_key: str, model_name: str, prompt: Optional[str] = None, provider_name: str | None = None):
+        super().__init__(model_name, provider_name=provider_name)
         self.client = OpenAI(base_url=base_url, api_key=api_key)
         self.prompt = prompt
 
@@ -686,17 +833,19 @@ class Mp3Stream(miniaudio.StreamableSource):
 
 class TTSModel(ABC):
     model_name: str
+    provider_name: str | None
 
-    def __init__(self, model_name: str):
+    def __init__(self, model_name: str, provider_name: str | None = None):
         self.model_name = model_name
+        self.provider_name = provider_name
 
     @abstractmethod
     def synthesize(self, text: str, voice: str) -> Iterable[bytes]:
         pass
 
 class OpenAITTSModel(TTSModel):
-    def __init__(self, base_url: str, api_key: str, model_name: str, speed: float = 1.0, voice_instructions: str | None = None):
-        super().__init__(model_name)
+    def __init__(self, base_url: str, api_key: str, model_name: str, speed: float = 1.0, voice_instructions: str | None = None, provider_name: str | None = None):
+        super().__init__(model_name, provider_name=provider_name)
         self.client = OpenAI(base_url=base_url, api_key=api_key)
         self.speed = speed
         self.voice_instructions = voice_instructions
@@ -729,8 +878,8 @@ class OpenAITTSModel(TTSModel):
             raise LLMError(f'TTS {e.response.reason_phrase}: {message}', e)
 
 class EdgeTTSModel(TTSModel):
-    def __init__(self, model_name: str, speed: float = 1.0):
-        super().__init__(model_name)
+    def __init__(self, model_name: str, speed: float = 1.0, provider_name: str | None = None):
+        super().__init__(model_name, provider_name=provider_name)
         self.speed = speed
         self.prebuffer_size = 4
 
@@ -830,12 +979,25 @@ def create_stt_model(provider: str, config: dict, prefix: str = "stt") -> STTMod
     if provider == "openai" or provider == "custom" or provider == "local-ai-server":
         if provider == "openai" and not base_url:
             base_url = "https://api.openai.com/v1"
-        return OpenAISTTModel(base_url, api_key, model_name, language, prompt)
-    
+        return OpenAISTTModel(
+            base_url,
+            api_key,
+            model_name,
+            language,
+            prompt,
+            provider_name=provider,
+        )
+
     elif provider == "google-ai-studio" or provider == "custom-multi-modal":
         if provider == "google-ai-studio" and not base_url:
             base_url = "https://generativelanguage.googleapis.com/v1beta"
-        return OpenAIMultiModalSTTModel(base_url, api_key, model_name, prompt)
+        return OpenAIMultiModalSTTModel(
+            base_url,
+            api_key,
+            model_name,
+            prompt,
+            provider_name=provider,
+        )
     
     return None
 
@@ -852,9 +1014,16 @@ def create_tts_model(provider: str, config: dict, prefix: str = "tts") -> TTSMod
     if provider == "openai" or provider == "custom" or provider == "local-ai-server":
         if provider == "openai" and not base_url:
             base_url = "https://api.openai.com/v1"
-        return OpenAITTSModel(base_url, api_key, model_name, speed, voice_instructions)
-    
+        return OpenAITTSModel(
+            base_url,
+            api_key,
+            model_name,
+            speed,
+            voice_instructions,
+            provider_name=provider,
+        )
+
     elif provider == "edge-tts":
-        return EdgeTTSModel(model_name, speed)
+        return EdgeTTSModel(model_name, speed, provider_name=provider)
     
     return None

--- a/src/lib/STT.py
+++ b/src/lib/STT.py
@@ -8,7 +8,15 @@ import pyaudio
 import speech_recognition as sr
 from pysilero_vad import SileroVoiceActivityDetector
 
-from .Logger import log, observe, show_chat_message
+from .Logger import (
+    AudioUsageStats,
+    LatencyUsageStats,
+    TextUsageStats,
+    log,
+    log_stt_usage,
+    observe,
+    show_chat_message,
+)
 from .Models import STTModel, LLMError
 
 
@@ -235,6 +243,15 @@ class STT:
         
         if self.required_word and self.required_word.lower() not in text.lower():
             return ''
+
+        log_stt_usage(
+            "speech",
+            provider=getattr(self.stt_model, "provider_name", None),
+            model_name=getattr(self.stt_model, "model_name", None),
+            latency_usage=LatencyUsageStats(response_ms=(end_time - start_time) * 1000),
+            audio_usage=AudioUsageStats(input_audio_duration_ms=audio_length * 1000),
+            text_usage=TextUsageStats(output_chars=len(text)),
+        )
 
         # print("transcription received", text)
         return text

--- a/src/lib/TTS.py
+++ b/src/lib/TTS.py
@@ -32,6 +32,7 @@ from .Config import (
     map_character_tts_postprocessing,
 )
 from .Logger import log, observe, show_chat_message
+from .Logger import AudioUsageStats, LatencyUsageStats, TextUsageStats, log_tts_usage
 from .Models import TTSModel, OpenAITTSModel
 
 
@@ -121,6 +122,7 @@ class TTS:
             return {
                 "type": "text",
                 "text": item,
+                "context": "speech",
                 "file_path": None,
                 "voice": None,
                 "postprocessing": None,
@@ -132,6 +134,7 @@ class TTS:
             return {
                 "type": item.get("type", "text"),
                 "text": item.get("text", ""),
+                "context": item.get("context", "speech"),
                 "file_path": item.get("file_path"),
                 "voice": item.get("voice"),
                 "postprocessing": item.get("postprocessing"),
@@ -143,6 +146,7 @@ class TTS:
         return {
             "type": "text",
             "text": "",
+            "context": "speech",
             "file_path": None,
             "voice": None,
             "postprocessing": None,
@@ -204,6 +208,7 @@ class TTS:
                     item = self._normalize_queue_item(self.read_queue.get())
                     item_type = item.get("type")
                     text = item.get("text")
+                    context = item.get("context")
                     file_path = item.get("file_path")
                     voice = item.get("voice")
                     postprocessing = item.get("postprocessing")
@@ -229,6 +234,7 @@ class TTS:
                             self._playback_one(
                                 text,
                                 stream,
+                                context if isinstance(context, str) else "speech",
                                 voice if isinstance(voice, str) else None,
                                 cast(CharacterTTSPostprocessingConfig | None, postprocessing if isinstance(postprocessing, dict) else None),
                                 cast(list[CharacterTTSPostprocessingConfig | None] | None, postprocessing_layers if isinstance(postprocessing_layers, list) else None),
@@ -254,6 +260,7 @@ class TTS:
         self,
         text: str,
         stream: pyaudio.Stream,
+        context: str = "speech",
         voice_override: str | None = None,
         postprocessing_override: CharacterTTSPostprocessingConfig | None = None,
         postprocessing_layers: list[CharacterTTSPostprocessingConfig | None] | None = None,
@@ -263,7 +270,8 @@ class TTS:
         text = strip_markdown.strip_markdown(text)
         # print('reading:', text)
         start_time = time()
-        end_time = None
+        first_byte_time = None
+        total_audio_bytes = 0
         first_chunk = True
         underflow_count = 0
         empty_buffer_available = stream.get_write_available()
@@ -272,14 +280,19 @@ class TTS:
             postprocessing_override,
             postprocessing_layers,
         )
-        audio_stream = self._stream_audio(text, voice_override)
+        stream_metrics: dict[str, float | None] = {
+            "response_ms": None,
+            "time_to_first_byte_ms": None,
+        }
+        audio_stream = self._stream_audio(text, voice_override, stream_metrics)
         if postprocessing:
             audio_stream = self._postprocess_audio(audio_stream, postprocessing)
 
         for chunk in audio_stream:
-            if not end_time:
-                end_time = time()
-                log('debug', f'Response time TTS', end_time - start_time)
+            total_audio_bytes += len(chunk)
+            if first_byte_time is None:
+                first_byte_time = time()
+                log('debug', f'Response time TTS', first_byte_time - start_time)
             if self.is_aborted:
                 break
             try:
@@ -302,6 +315,26 @@ class TTS:
         if underflow_count > 0:
             self.prebuffer_size *= 2
             log('debug', 'tts underflow detected, total', underflow_count, 'increasing prebuffer size to', self.prebuffer_size)
+
+        output_audio_duration_ms = 0.0
+        if total_audio_bytes > 0:
+            output_audio_duration_ms = (
+                total_audio_bytes / (24_000 * self.sample_size)
+            ) * 1000
+
+        log_tts_usage(
+            context,
+            provider=getattr(self.tts_model, "provider_name", None),
+            model_name=getattr(self.tts_model, "model_name", None),
+            latency_usage=LatencyUsageStats(
+                response_ms=stream_metrics.get("response_ms"),
+                time_to_first_byte_ms=stream_metrics.get("time_to_first_byte_ms"),
+            ),
+            audio_usage=AudioUsageStats(
+                output_audio_duration_ms=output_audio_duration_ms,
+            ),
+            text_usage=TextUsageStats(input_chars=len(text)),
+        )
 
 
     def _reset_postprocessing_state(self) -> None:
@@ -456,19 +489,33 @@ class TTS:
                 base_effect['mode'] = overlay_effect['mode']
 
     @observe()
-    def _stream_audio(self, text: str, voice_override: str | None = None):
+    def _stream_audio(
+        self,
+        text: str,
+        voice_override: str | None = None,
+        metrics: dict[str, float | None] | None = None,
+    ):
+        started_at = time()
         if self.tts_model is None:
             word_count = len(text.split())
             words_per_minute = 150 * float(self.speed)
             audio_duration = word_count / words_per_minute * 60
             # generate silent audio for the duration of the text
             for _ in range(int(audio_duration * 24_000 / 1024)):
+                if metrics is not None and metrics.get("time_to_first_byte_ms") is None:
+                    metrics["time_to_first_byte_ms"] = (time() - started_at) * 1000
                 yield b"\x00" * 1024
+            if metrics is not None:
+                metrics["response_ms"] = (time() - started_at) * 1000
         else:
             try:
                 selected_voice = voice_override if voice_override else self.voice
                 for chunk in self.tts_model.synthesize(text, selected_voice):
+                    if metrics is not None and metrics.get("time_to_first_byte_ms") is None:
+                        metrics["time_to_first_byte_ms"] = (time() - started_at) * 1000
                     yield chunk
+                if metrics is not None:
+                    metrics["response_ms"] = (time() - started_at) * 1000
             except Exception as e:
                 log('error', 'TTS synthesis error', e, traceback.format_exc())
                 show_chat_message('error', 'TTS synthesis error:', str(e))
@@ -1259,6 +1306,7 @@ class TTS:
         self,
         text: str,
         *,
+        context: str = "speech",
         voice: str | None = None,
         postprocessing: CharacterTTSPostprocessingConfig | None = None,
         postprocessing_layers: list[CharacterTTSPostprocessingConfig | None] | None = None,
@@ -1269,6 +1317,7 @@ class TTS:
         self.read_queue.put(
             {
                 "text": text,
+                "context": context,
                 "voice": voice,
                 "postprocessing": postprocessing,
                 "postprocessing_layers": postprocessing_layers,

--- a/test/lib/test_Logger.py
+++ b/test/lib/test_Logger.py
@@ -11,6 +11,8 @@ import sqlite_vec
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src.lib.Logger import ModelUsageStats, PromptUsageStats, log_llm_usage
+from src.lib.Logger import AudioUsageStats, LatencyUsageStats, TextUsageStats, log_stt_usage, log_tts_usage
+from src.lib.Logger import CacheUsageStats, log_action_cache_usage
 from src.lib.Database import ModelUsageStore, set_connection_for_testing
 from src.lib.Models import OpenAIResponsesLLMModel, _get_reasoning_tokens
 
@@ -47,6 +49,8 @@ def test_log_llm_usage_includes_provider_model_and_reasoning_tokens(
         reasoning_tokens=7,
         provider="openai",
         model_name="gpt-5",
+        response_ms=842,
+        output_chars=17,
     )
 
     log_llm_usage("assistant", usage, PromptUsageStats(system_chars=20))
@@ -62,10 +66,13 @@ def test_log_llm_usage_includes_provider_model_and_reasoning_tokens(
     assert message["type"] == "llm_usage"
     assert message["provider"] == "openai"
     assert message["model_name"] == "gpt-5"
+    assert message["schema_version"] == 2
     assert message["model_usage"]["reasoning_tokens"] == 7
     assert message["model_usage"]["provider"] == "openai"
     assert message["model_usage"]["model_name"] == "gpt-5"
     assert message["prompt_usage"]["total_prompt_chars"] == 20
+    assert message["latency_usage"]["response_ms"] == 842
+    assert message["text_usage"]["output_chars"] == 17
 
     rows, total = ModelUsageStore().get_history(usage_kind="llm")
     assert total == 1
@@ -74,6 +81,84 @@ def test_log_llm_usage_includes_provider_model_and_reasoning_tokens(
     assert rows[0]["payload"]["provider"] == "openai"
     assert rows[0]["payload"]["model_usage"]["reasoning_tokens"] == 7
     assert rows[0]["payload"]["prompt_usage"]["total_prompt_chars"] == 20
+    assert rows[0]["payload"]["latency_usage"]["response_ms"] == 842
+    assert rows[0]["payload"]["text_usage"]["output_chars"] == 17
+
+
+def test_log_stt_and_tts_usage_persist_new_metric_groups(
+    capsys, mock_connection
+) -> None:
+    _ = mock_connection
+
+    log_stt_usage(
+        "speech",
+        provider="openai",
+        model_name="gpt-4o-mini-transcribe",
+        latency_usage=LatencyUsageStats(response_ms=321),
+        audio_usage=AudioUsageStats(input_audio_duration_ms=2500),
+        text_usage=TextUsageStats(output_chars=42),
+    )
+    log_tts_usage(
+        "assistant",
+        provider="edge-tts",
+        model_name="edge-tts",
+        latency_usage=LatencyUsageStats(response_ms=555, time_to_first_byte_ms=120),
+        audio_usage=AudioUsageStats(output_audio_duration_ms=4200),
+        text_usage=TextUsageStats(input_chars=88),
+    )
+
+    output_lines = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    usage_messages = [
+        line for line in output_lines if line.get("type") in {"stt_usage", "tts_usage"}
+    ]
+
+    assert len(usage_messages) == 2
+    assert usage_messages[0]["audio_usage"]["input_audio_duration_ms"] == 2500
+    assert usage_messages[0]["text_usage"]["output_chars"] == 42
+    assert usage_messages[1]["latency_usage"]["time_to_first_byte_ms"] == 120
+    assert usage_messages[1]["audio_usage"]["output_audio_duration_ms"] == 4200
+    assert usage_messages[1]["text_usage"]["input_chars"] == 88
+
+    rows, total = ModelUsageStore().get_history(limit=10)
+    assert total == 2
+    assert rows[0]["usage_kind"] == "tts"
+    assert rows[0]["payload"]["latency_usage"]["time_to_first_byte_ms"] == 120
+    assert rows[1]["usage_kind"] == "stt"
+    assert rows[1]["payload"]["audio_usage"]["input_audio_duration_ms"] == 2500
+
+
+def test_log_action_cache_usage_persists_saved_llm_calls(
+    capsys, mock_connection
+) -> None:
+    _ = mock_connection
+
+    log_action_cache_usage(
+        "assistant",
+        provider="openai",
+        model_name="gpt-5",
+        cache_usage=CacheUsageStats(llm_calls_saved=1),
+    )
+
+    output_lines = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    message = next(
+        line for line in reversed(output_lines) if line.get("type") == "action_cache_usage"
+    )
+
+    assert message["context"] == "assistant"
+    assert message["cache_usage"]["llm_calls_saved"] == 1
+
+    rows, total = ModelUsageStore().get_history(usage_kind="llm")
+    assert total == 1
+    assert rows[0]["payload"]["type"] == "action_cache_usage"
+    assert rows[0]["payload"]["cache_usage"]["llm_calls_saved"] == 1
 
 
 def test_openai_responses_model_usage_captures_reasoning_tokens(
@@ -122,6 +207,8 @@ def test_openai_responses_model_usage_captures_reasoning_tokens(
     assert usage.reasoning_tokens == 4
     assert usage.provider == "openai"
     assert usage.model_name == "gpt-5"
+    assert usage.response_ms is not None
+    assert usage.output_chars == 2
 
 
 def test_get_reasoning_tokens_falls_back_to_usage_totals() -> None:

--- a/ui/src/app/components/model-usage-analytics/model-usage-analytics.component.html
+++ b/ui/src/app/components/model-usage-analytics/model-usage-analytics.component.html
@@ -14,6 +14,15 @@
       </mat-form-field>
 
       <mat-form-field appearance="outline">
+        <mat-label>Usage Kind</mat-label>
+        <mat-select [(ngModel)]="selectedUsageKind" (ngModelChange)="onUsageKindChange()">
+          @for (kind of usageKinds; track kind) {
+            <mat-option [value]="kind">{{ formatUsageKindLabel(kind) }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
         <mat-label>Provider</mat-label>
         <mat-select [(ngModel)]="selectedProvider" (ngModelChange)="onProviderChange()">
           <mat-option value="all">All providers</mat-option>
@@ -113,6 +122,31 @@
     </section>
 
     <section class="analytics-grid">
+      <mat-card class="analytics-card">
+        <div class="card-header compact">
+          <div>
+            <p class="card-kicker">Usage Kinds</p>
+            <h3>Call distribution by kind</h3>
+          </div>
+        </div>
+
+        <div class="bar-list">
+          @for (bar of usageKindBars; track bar.label) {
+            <div class="bar-row">
+              <div class="bar-copy">
+                <span class="bar-label">{{ bar.label }}</span>
+                <span class="bar-subtitle">{{ bar.subtitle }}</span>
+              </div>
+              <div class="bar-track">
+                <div class="bar-fill" [class]="'tone-' + bar.tone" [style.width.%]="bar.widthPct" [attr.title]="formatBreakdownBarTitle(bar)"></div>
+              </div>
+              <span class="bar-value">{{ bar.valueLabel }}</span>
+            </div>
+          }
+        </div>
+      </mat-card>
+
+      @if (hasTokenMetrics) {
       <mat-card class="analytics-card wide-card">
         <div class="card-header">
           <div>
@@ -147,7 +181,9 @@
           }
         </div>
       </mat-card>
+      }
 
+      @if (hasPromptMetrics) {
       <mat-card class="analytics-card wide-card">
         <div class="card-header">
           <div>
@@ -183,7 +219,9 @@
           }
         </div>
       </mat-card>
+      }
 
+      @if (hasTokenMetrics) {
       <mat-card class="analytics-card">
         <div class="card-header compact">
           <div>
@@ -207,7 +245,9 @@
           }
         </div>
       </mat-card>
+      }
 
+      @if (hasPromptMetrics) {
       <mat-card class="analytics-card">
         <div class="card-header compact">
           <div>
@@ -231,7 +271,9 @@
           }
         </div>
       </mat-card>
+      }
 
+      @if (hasTokenMetrics) {
       <mat-card class="analytics-card">
         <div class="card-header compact">
           <div>
@@ -255,12 +297,14 @@
           }
         </div>
       </mat-card>
+      }
 
+      @if (hasTokenMetrics) {
       <mat-card class="analytics-card">
         <div class="card-header compact">
           <div>
             <p class="card-kicker">Models</p>
-            <h3>Token share by model</h3>
+            <h3>Token share by llm model</h3>
           </div>
         </div>
 
@@ -279,6 +323,7 @@
           }
         </div>
       </mat-card>
+      }
     </section>
 
     <mat-card class="recent-card">
@@ -294,15 +339,50 @@
           <div class="recent-row">
             <div class="recent-main">
               <span class="recent-context">{{ formatContextLabel(row.context) }}</span>
+              <span class="recent-model">{{ formatUsageKindLabel($any(row.usageKind)) }}</span>
               <span class="recent-model">{{ row.provider }} / {{ row.modelName }}</span>
             </div>
 
             <div class="recent-metrics">
-              <span class="metric-pill metric-cached-input">{{ row.tokenUsage.cachedTokens | number }} cached</span>
-              <span class="metric-pill metric-live-input">{{ row.tokenUsage.liveInputTokens | number }} sent</span>
-              <span class="metric-pill metric-thinking-output">{{ row.tokenUsage.reasoningTokens | number }} thinking</span>
-              <span class="metric-pill metric-visible-output">{{ row.tokenUsage.visibleOutputTokens | number }} output</span>
-              <span class="metric-pill char-pill">{{ row.promptUsage.totalChars | number }} chars</span>
+              @if (row.tokenUsage.cachedTokens > 0) {
+                <span class="metric-pill metric-cached-input">{{ row.tokenUsage.cachedTokens | number }} cached</span>
+              }
+              @if (row.tokenUsage.liveInputTokens > 0) {
+                <span class="metric-pill metric-live-input">{{ row.tokenUsage.liveInputTokens | number }} sent</span>
+              }
+              @if (row.tokenUsage.reasoningTokens > 0) {
+                <span class="metric-pill metric-thinking-output">{{ row.tokenUsage.reasoningTokens | number }} thinking</span>
+              }
+              @if (row.tokenUsage.visibleOutputTokens > 0) {
+                <span class="metric-pill metric-visible-output">{{ row.tokenUsage.visibleOutputTokens | number }} output</span>
+              }
+              @if (row.promptUsage.totalChars > 0) {
+                <span class="metric-pill metric-live-input">{{ row.promptUsage.totalChars | number }} prompt chars</span>
+              }
+              @if (row.latencyUsage.responseMs !== null) {
+                <span class="metric-pill metric-thinking-output">{{ row.latencyUsage.responseMs | number:'1.0-0' }} ms response</span>
+              }
+              @if (row.latencyUsage.timeToFirstByteMs !== null) {
+                <span class="metric-pill metric-thinking-output">{{ row.latencyUsage.timeToFirstByteMs | number:'1.0-0' }} ms first byte</span>
+              }
+              @if (row.audioUsage.inputAudioDurationMs !== null) {
+                <span class="metric-pill metric-live-input">{{ row.audioUsage.inputAudioDurationMs | number:'1.0-0' }} ms input audio</span>
+              }
+              @if (row.audioUsage.outputAudioDurationMs !== null) {
+                <span class="metric-pill metric-visible-output">{{ row.audioUsage.outputAudioDurationMs | number:'1.0-0' }} ms output audio</span>
+              }
+              @if (row.textUsage.inputChars !== null) {
+                <span class="metric-pill metric-live-input">{{ row.textUsage.inputChars | number }} input chars</span>
+              }
+              @if (row.textUsage.outputChars !== null) {
+                <span class="metric-pill metric-visible-output">{{ row.textUsage.outputChars | number }} output chars</span>
+              }
+              @if (row.cacheUsage.llmCallsSaved > 0) {
+                <span class="metric-pill metric-cache-saved">{{ row.cacheUsage.llmCallsSaved | number }} llm saved</span>
+              }
+              @if (row.cacheUsage.llmCallsAdded > 0) {
+                <span class="metric-pill metric-thinking-output">{{ row.cacheUsage.llmCallsAdded | number }} extra llm</span>
+              }
             </div>
 
             <span class="recent-time">{{ row.timestamp | date:'medium' }}</span>

--- a/ui/src/app/components/model-usage-analytics/model-usage-analytics.component.scss
+++ b/ui/src/app/components/model-usage-analytics/model-usage-analytics.component.scss
@@ -258,6 +258,11 @@
   color: #ffcb7f;
 }
 
+.metric-cache-saved {
+  background: rgba(94, 231, 183, 0.16);
+  color: #a3f3d6;
+}
+
 .legend-chars,
 .char-pill {
   background: rgba(94, 231, 183, 0.16);

--- a/ui/src/app/components/model-usage-analytics/model-usage-analytics.component.ts
+++ b/ui/src/app/components/model-usage-analytics/model-usage-analytics.component.ts
@@ -15,9 +15,11 @@ import {
     ModelUsageRecord,
     ModelUsageService,
     TimeWindowPreset,
+    UsageKind,
 } from "../../services/model-usage.service";
 
 type TimelineGranularity = "hour" | "day" | "week";
+type UsageKindOption = "all" | UsageKind;
 
 interface SummaryCard {
     label: string;
@@ -91,8 +93,10 @@ interface TimelineBucket {
 })
 export class ModelUsageAnalyticsComponent implements OnInit {
     protected readonly presets: TimeWindowPreset[] = ["24h", "7d", "30d", "all", "custom"];
+    protected readonly usageKinds: UsageKindOption[] = ["all", "llm", "stt", "tts"];
 
     public selectedPreset: TimeWindowPreset = "7d";
+    public selectedUsageKind: UsageKindOption = "all";
     public selectedProvider = "all";
     public selectedModel = "all";
     public selectedContext = "all";
@@ -113,6 +117,7 @@ export class ModelUsageAnalyticsComponent implements OnInit {
     public tokenTimelineBars: TimelineBar[] = [];
     public characterTimelineBars: TimelineBar[] = [];
     public useCaseTokenBars: BreakdownBar[] = [];
+    public usageKindBars: BreakdownBar[] = [];
     public characterTypeBars: BreakdownBar[] = [];
     public providerBars: BreakdownBar[] = [];
     public modelBars: BreakdownBar[] = [];
@@ -143,6 +148,10 @@ export class ModelUsageAnalyticsComponent implements OnInit {
         await this.loadWindow();
     }
 
+    public async onUsageKindChange(): Promise<void> {
+        await this.loadWindow();
+    }
+
     public async refreshData(): Promise<void> {
         this.modelUsageService.clearCache();
         await this.loadWindow();
@@ -150,6 +159,7 @@ export class ModelUsageAnalyticsComponent implements OnInit {
 
     public async resetFilters(): Promise<void> {
         this.selectedPreset = "7d";
+        this.selectedUsageKind = "all";
         this.selectedProvider = "all";
         this.selectedModel = "all";
         this.selectedContext = "all";
@@ -215,6 +225,16 @@ export class ModelUsageAnalyticsComponent implements OnInit {
         return labels[preset];
     }
 
+    public formatUsageKindLabel(kind: UsageKindOption): string {
+        const labels: Record<UsageKindOption, string> = {
+            all: "All kinds",
+            llm: "LLM",
+            stt: "STT",
+            tts: "TTS",
+        };
+        return labels[kind];
+    }
+
     public formatTimelineSegmentTitle(
         bar: TimelineBar,
         segment: TimelineSegment,
@@ -233,6 +253,34 @@ export class ModelUsageAnalyticsComponent implements OnInit {
             return false;
         }
         return this.customFromDate.getTime() <= this.customToDate.getTime();
+    }
+
+    public get hasTokenMetrics(): boolean {
+        return this.filteredRows.some((row) => row.tokenUsage.totalTokens > 0);
+    }
+
+    public get hasPromptMetrics(): boolean {
+        return this.filteredRows.some((row) => row.promptUsage.totalChars > 0);
+    }
+
+    public get hasLatencyMetrics(): boolean {
+        return this.filteredRows.some((row) => row.latencyUsage.responseMs !== null);
+    }
+
+    public get hasAudioMetrics(): boolean {
+        return this.filteredRows.some(
+            (row) =>
+                row.audioUsage.inputAudioDurationMs !== null ||
+                row.audioUsage.outputAudioDurationMs !== null,
+        );
+    }
+
+    public get hasTextMetrics(): boolean {
+        return this.filteredRows.some(
+            (row) =>
+                row.textUsage.inputChars !== null ||
+                row.textUsage.outputChars !== null,
+        );
     }
 
     private async loadWindow(): Promise<void> {
@@ -260,6 +308,7 @@ export class ModelUsageAnalyticsComponent implements OnInit {
             this.tokenTimelineBars = [];
             this.characterTimelineBars = [];
             this.useCaseTokenBars = [];
+            this.usageKindBars = [];
             this.characterTypeBars = [];
             this.providerBars = [];
             this.modelBars = [];
@@ -269,11 +318,12 @@ export class ModelUsageAnalyticsComponent implements OnInit {
         }
     }
 
-    private buildWindowQuery(): { usageKind: string; from?: string; to?: string } {
+    private buildWindowQuery(): { usageKind?: string; from?: string; to?: string } {
+        const usageKind = this.selectedUsageKind === "all" ? undefined : this.selectedUsageKind;
         const now = new Date();
 
         if (this.selectedPreset === "all") {
-            return { usageKind: "llm" };
+            return usageKind ? { usageKind } : {};
         }
 
         if (this.selectedPreset === "custom") {
@@ -285,7 +335,7 @@ export class ModelUsageAnalyticsComponent implements OnInit {
                 : undefined;
 
             return {
-                usageKind: "llm",
+                usageKind,
                 from,
                 to,
             };
@@ -301,7 +351,7 @@ export class ModelUsageAnalyticsComponent implements OnInit {
         }
 
         return {
-            usageKind: "llm",
+            usageKind,
             from: from.toISOString(),
             to: now.toISOString(),
         };
@@ -353,82 +403,235 @@ export class ModelUsageAnalyticsComponent implements OnInit {
             return true;
         });
 
+        const llmRows = this.filteredRows.filter((row) => row.usageKind === "llm");
+
         this.summaryCards = this.buildSummaryCards(this.filteredRows);
         this.tokenTimelineBars = this.buildTimelineBars(this.filteredRows, "tokens");
         this.characterTimelineBars = this.buildTimelineBars(this.filteredRows, "chars");
-        this.useCaseTokenBars = this.buildContextBars(this.filteredRows, "tokens");
+        this.useCaseTokenBars = this.buildContextBars(llmRows, "tokens");
+        this.usageKindBars = this.buildUsageKindBars(this.filteredRows);
         this.characterTypeBars = this.buildCharacterTypeBars(this.filteredRows);
-        this.providerBars = this.buildGroupBars(this.filteredRows, "provider");
-        this.modelBars = this.buildGroupBars(this.filteredRows, "model");
+        this.providerBars = this.buildGroupBars(llmRows, "provider");
+        this.modelBars = this.buildGroupBars(llmRows, "model");
         this.recentRows = this.filteredRows.slice(0, 18);
     }
 
     private buildSummaryCards(rows: ModelUsageRecord[]): SummaryCard[] {
-        const totalTokens = rows.reduce(
+        const cards: SummaryCard[] = [];
+        const requestRows = rows.filter((row) => row.messageType !== "action_cache_usage");
+        const llmRows = rows.filter((row) => row.usageKind === "llm");
+        const llmRequestRows = llmRows.filter(
+            (row) => row.messageType !== "action_cache_usage",
+        );
+        const sttRows = rows.filter((row) => row.usageKind === "stt");
+        const ttsRows = rows.filter((row) => row.usageKind === "tts");
+        const actionCacheSavedCalls = rows.reduce(
+            (sum, row) => sum + row.cacheUsage.llmCallsSaved,
+            0,
+        );
+        const actionCacheAddedCalls =
+            rows.reduce((sum, row) => sum + row.cacheUsage.llmCallsAdded, 0) +
+            llmRequestRows.filter((row) => row.context === "action_verification").length;
+
+        const totalTokens = llmRows.reduce(
             (sum, row) => sum + row.tokenUsage.totalTokens,
             0,
         );
-        const cachedInputTokens = rows.reduce(
+        const cachedInputTokens = llmRows.reduce(
             (sum, row) => sum + row.tokenUsage.cachedTokens,
             0,
         );
-        const liveInputTokens = rows.reduce(
+        const liveInputTokens = llmRows.reduce(
             (sum, row) => sum + row.tokenUsage.liveInputTokens,
             0,
         );
-        const thinkingOutputTokens = rows.reduce(
+        const thinkingOutputTokens = llmRows.reduce(
             (sum, row) => sum + row.tokenUsage.reasoningTokens,
             0,
         );
-        const visibleOutputTokens = rows.reduce(
+        const visibleOutputTokens = llmRows.reduce(
             (sum, row) => sum + row.tokenUsage.visibleOutputTokens,
             0,
         );
-        const promptChars = rows.reduce(
+        const promptChars = llmRows.reduce(
             (sum, row) => sum + row.promptUsage.totalChars,
             0,
         );
+        const responseLatencies = rows
+            .map((row) => row.latencyUsage.responseMs)
+            .filter((value): value is number => value !== null);
+        const firstByteLatencies = rows
+            .map((row) => row.latencyUsage.timeToFirstByteMs)
+            .filter((value): value is number => value !== null);
+        const inputAudioDurationMs = rows.reduce(
+            (sum, row) => sum + (row.audioUsage.inputAudioDurationMs ?? 0),
+            0,
+        );
+        const outputAudioDurationMs = rows.reduce(
+            (sum, row) => sum + (row.audioUsage.outputAudioDurationMs ?? 0),
+            0,
+        );
+        const ttsInputChars = ttsRows.reduce(
+            (sum, row) => sum + (row.textUsage.inputChars ?? 0),
+            0,
+        );
+        const llmOutputChars = llmRows.reduce(
+            (sum, row) => sum + (row.textUsage.outputChars ?? 0),
+            0,
+        );
+        const sttOutputChars = sttRows.reduce(
+            (sum, row) => sum + (row.textUsage.outputChars ?? 0),
+            0,
+        );
 
-        const avgTokens = rows.length > 0 ? Math.round(totalTokens / rows.length) : 0;
+        const avgTokens =
+            llmRequestRows.length > 0
+                ? Math.round(totalTokens / llmRequestRows.length)
+                : 0;
 
-        return [
-            {
-                label: "Calls",
-                value: this.formatCompactNumber(rows.length),
-                detail: `${this.formatCompactNumber(avgTokens)} avg tokens per call`,
-                tone: "amber",
-            },
-            {
-                label: "Total Tokens",
-                value: this.formatCompactNumber(totalTokens),
-                detail: `${this.formatCompactNumber(cachedInputTokens)} cached + ${this.formatCompactNumber(liveInputTokens)} sent`,
-                tone: "blue",
-            },
-            {
-                label: "Cached Sent",
-                value: this.formatCompactNumber(cachedInputTokens),
-                detail: `${this.formatPercent(cachedInputTokens, totalTokens)} of total tokens`,
-                tone: "slate",
-            },
-            {
-                label: "Sent",
-                value: this.formatCompactNumber(liveInputTokens),
-                detail: `${this.formatPercent(liveInputTokens, totalTokens)} of total tokens`,
-                tone: "amber",
-            },
-            {
-                label: "Thinking Output",
-                value: this.formatCompactNumber(thinkingOutputTokens),
-                detail: `${this.formatPercent(thinkingOutputTokens, totalTokens)} of total tokens`,
-                tone: "violet",
-            },
-            {
-                label: "Output",
-                value: this.formatCompactNumber(visibleOutputTokens),
-                detail: `${this.formatPercent(visibleOutputTokens, totalTokens)} of total tokens`,
+        cards.push({
+            label: "Calls",
+            value: this.formatCompactNumber(requestRows.length),
+            detail:
+                totalTokens > 0
+                    ? `${this.formatCompactNumber(avgTokens)} avg tokens per call`
+                    : "persisted usage rows",
+            tone: "amber",
+        });
+
+        if (totalTokens > 0) {
+            cards.push(
+                {
+                    label: "Total Tokens",
+                    value: this.formatCompactNumber(totalTokens),
+                    detail: `${this.formatCompactNumber(cachedInputTokens)} cached + ${this.formatCompactNumber(liveInputTokens)} sent`,
+                    tone: "blue",
+                },
+                {
+                    label: "Cached Sent",
+                    value: this.formatCompactNumber(cachedInputTokens),
+                    detail: `${this.formatPercent(cachedInputTokens, totalTokens)} of total tokens`,
+                    tone: "slate",
+                },
+                {
+                    label: "Sent",
+                    value: this.formatCompactNumber(liveInputTokens),
+                    detail: `${this.formatPercent(liveInputTokens, totalTokens)} of total tokens`,
+                    tone: "amber",
+                },
+                {
+                    label: "Thinking Output",
+                    value: this.formatCompactNumber(thinkingOutputTokens),
+                    detail: `${this.formatPercent(thinkingOutputTokens, totalTokens)} of total tokens`,
+                    tone: "violet",
+                },
+                {
+                    label: "Output",
+                    value: this.formatCompactNumber(visibleOutputTokens),
+                    detail: `${this.formatPercent(visibleOutputTokens, totalTokens)} of total tokens`,
+                    tone: "mint",
+                },
+            );
+        }
+
+        if (promptChars > 0) {
+            cards.push({
+                label: "Prompt Chars",
+                value: this.formatCompactNumber(promptChars),
+                detail: `${this.formatCompactNumber(Math.round(promptChars / Math.max(llmRequestRows.length, 1)))} avg chars per call`,
+                tone: "rose",
+            });
+        }
+
+        if (actionCacheSavedCalls > 0 || actionCacheAddedCalls > 0) {
+            cards.push({
+                label: "Cache Saved",
+                value: this.formatCompactNumber(actionCacheSavedCalls),
+                detail: `${this.formatCompactNumber(actionCacheAddedCalls)} extra verification calls`,
                 tone: "mint",
-            },
-        ];
+            });
+
+            cards.push({
+                label: "Cache Net",
+                value: this.formatCompactNumber(
+                    actionCacheSavedCalls - actionCacheAddedCalls,
+                ),
+                detail:
+                    actionCacheAddedCalls > 0
+                        ? `${this.formatCompactNumber(actionCacheSavedCalls)} saved vs ${this.formatCompactNumber(actionCacheAddedCalls)} extra calls`
+                        : "no extra verification calls",
+                tone: "slate",
+            });
+        }
+
+        if (responseLatencies.length > 0) {
+            const avgResponseMs =
+                responseLatencies.reduce((sum, value) => sum + value, 0) /
+                responseLatencies.length;
+            cards.push({
+                label: "Avg Response",
+                value: this.formatDuration(avgResponseMs),
+                detail: `${this.formatDuration(this.percentile(responseLatencies, 95))} p95 response time`,
+                tone: "violet",
+            });
+        }
+
+        if (firstByteLatencies.length > 0) {
+            const avgFirstByteMs =
+                firstByteLatencies.reduce((sum, value) => sum + value, 0) /
+                firstByteLatencies.length;
+            cards.push({
+                label: "Avg TTS First Byte",
+                value: this.formatDuration(avgFirstByteMs),
+                detail: `${this.formatDuration(this.percentile(firstByteLatencies, 95))} p95 first byte`,
+                tone: "mint",
+            });
+        }
+
+        if (inputAudioDurationMs > 0) {
+            cards.push({
+                label: "Input Audio",
+                value: this.formatDuration(inputAudioDurationMs),
+                detail: "captured by STT requests",
+                tone: "blue",
+            });
+        }
+
+        if (outputAudioDurationMs > 0) {
+            cards.push({
+                label: "Output Audio",
+                value: this.formatDuration(outputAudioDurationMs),
+                detail: "generated by TTS requests",
+                tone: "slate",
+            });
+        }
+
+        if (this.selectedUsageKind === "tts" && ttsInputChars > 0) {
+            cards.push({
+                label: "Input Chars",
+                value: this.formatCompactNumber(ttsInputChars),
+                detail: "text sent into TTS",
+                tone: "amber",
+            });
+        }
+
+        if (this.selectedUsageKind === "stt" && sttOutputChars > 0) {
+            cards.push({
+                label: "Output Chars",
+                value: this.formatCompactNumber(sttOutputChars),
+                detail: "characters returned by STT",
+                tone: "mint",
+            });
+        } else if (llmOutputChars > 0) {
+            cards.push({
+                label: "Output Chars",
+                value: this.formatCompactNumber(llmOutputChars),
+                detail: "characters returned by LLM",
+                tone: "mint",
+            });
+        }
+
+        return cards;
     }
 
     private buildTimelineBars(
@@ -673,6 +876,9 @@ export class ModelUsageAnalyticsComponent implements OnInit {
                 metric === "tokens"
                     ? row.tokenUsage.totalTokens
                     : row.promptUsage.totalChars;
+            if (value <= 0) {
+                continue;
+            }
             const existing = groups.get(key) ?? { value: 0, count: 0 };
             existing.value += value;
             existing.count += 1;
@@ -744,6 +950,26 @@ export class ModelUsageAnalyticsComponent implements OnInit {
             });
     }
 
+    private buildUsageKindBars(rows: ModelUsageRecord[]): BreakdownBar[] {
+        const groups = new Map<string, number>();
+
+        for (const row of rows) {
+            groups.set(row.usageKind, (groups.get(row.usageKind) ?? 0) + 1);
+        }
+
+        return this.toBreakdownBars(
+            Array.from(groups.entries()).map(([label, count], index) => ({
+                label: this.formatUsageKindLabel(label as UsageKindOption),
+                value: count,
+                valueLabel: this.formatCompactNumber(count),
+                subtitle: "calls",
+                tone: this.pickTone(index),
+            })),
+            4,
+            true,
+        );
+    }
+
     private buildGroupBars(
         rows: ModelUsageRecord[],
         groupBy: "provider" | "model",
@@ -751,6 +977,9 @@ export class ModelUsageAnalyticsComponent implements OnInit {
         const groups = new Map<string, { value: number; count: number }>();
 
         for (const row of rows) {
+            if (row.tokenUsage.totalTokens <= 0) {
+                continue;
+            }
             const key = groupBy === "provider" ? row.provider : row.modelName;
             const existing = groups.get(key) ?? { value: 0, count: 0 };
             existing.value += row.tokenUsage.totalTokens;
@@ -903,8 +1132,33 @@ export class ModelUsageAnalyticsComponent implements OnInit {
         }).format(Math.round(value));
     }
 
+    private formatDuration(valueMs: number): string {
+        if (!Number.isFinite(valueMs) || valueMs <= 0) {
+            return "0 ms";
+        }
+
+        if (valueMs < 1000) {
+            return `${Math.round(valueMs)} ms`;
+        }
+
+        return `${(valueMs / 1000).toFixed(valueMs >= 10_000 ? 0 : 1)} s`;
+    }
+
     private formatFullNumber(value: number): string {
         return new Intl.NumberFormat().format(Math.round(value));
+    }
+
+    private percentile(values: number[], percentile: number): number {
+        if (values.length === 0) {
+            return 0;
+        }
+
+        const sorted = [...values].sort((left, right) => left - right);
+        const index = Math.min(
+            sorted.length - 1,
+            Math.max(0, Math.ceil((percentile / 100) * sorted.length) - 1),
+        );
+        return sorted[index];
     }
 
     private formatPercent(value: number, total: number): string {

--- a/ui/src/app/services/model-usage.service.ts
+++ b/ui/src/app/services/model-usage.service.ts
@@ -15,6 +15,8 @@ export interface ModelUsageWindowQuery {
     to?: string | null;
 }
 
+export type UsageKind = "llm" | "stt" | "tts";
+
 interface PersistedModelUsageRow {
     id: number;
     timestamp: string;
@@ -52,6 +54,27 @@ export interface TokenUsageBreakdown {
     visibleOutputTokens: number;
 }
 
+export interface LatencyUsageBreakdown {
+    responseMs: number | null;
+    timeToFirstTokenMs: number | null;
+    timeToFirstByteMs: number | null;
+}
+
+export interface AudioUsageBreakdown {
+    inputAudioDurationMs: number | null;
+    outputAudioDurationMs: number | null;
+}
+
+export interface TextUsageBreakdown {
+    inputChars: number | null;
+    outputChars: number | null;
+}
+
+export interface CacheUsageBreakdown {
+    llmCallsSaved: number;
+    llmCallsAdded: number;
+}
+
 export interface ModelUsageRecord {
     id: number;
     timestamp: string;
@@ -63,6 +86,10 @@ export interface ModelUsageRecord {
     modelName: string;
     tokenUsage: TokenUsageBreakdown;
     promptUsage: PromptUsageBreakdown;
+    latencyUsage: LatencyUsageBreakdown;
+    audioUsage: AudioUsageBreakdown;
+    textUsage: TextUsageBreakdown;
+    cacheUsage: CacheUsageBreakdown;
     raw: Record<string, unknown>;
 }
 
@@ -124,7 +151,7 @@ export class ModelUsageService implements OnDestroy {
             return cached;
         }
 
-        const usageKind = query.usageKind ?? "llm";
+        const usageKind = query.usageKind;
         const allRows: ModelUsageRecord[] = [];
         const limit = 1000;
         let offset = 0;
@@ -162,7 +189,7 @@ export class ModelUsageService implements OnDestroy {
 
     private getCacheKey(query: ModelUsageWindowQuery): string {
         return JSON.stringify({
-            usageKind: query.usageKind ?? "llm",
+            usageKind: query.usageKind ?? null,
             from: query.from ?? null,
             to: query.to ?? null,
         });
@@ -220,10 +247,55 @@ export class ModelUsageService implements OnDestroy {
         };
     }
 
+    private buildLatencyUsage(
+        latencyUsage: Record<string, unknown>,
+    ): LatencyUsageBreakdown {
+        return {
+            responseMs: this.toNullableNumber(latencyUsage["response_ms"]),
+            timeToFirstTokenMs: this.toNullableNumber(
+                latencyUsage["time_to_first_token_ms"],
+            ),
+            timeToFirstByteMs: this.toNullableNumber(
+                latencyUsage["time_to_first_byte_ms"],
+            ),
+        };
+    }
+
+    private buildAudioUsage(audioUsage: Record<string, unknown>): AudioUsageBreakdown {
+        return {
+            inputAudioDurationMs: this.toNullableNumber(
+                audioUsage["input_audio_duration_ms"],
+            ),
+            outputAudioDurationMs: this.toNullableNumber(
+                audioUsage["output_audio_duration_ms"],
+            ),
+        };
+    }
+
+    private buildTextUsage(textUsage: Record<string, unknown>): TextUsageBreakdown {
+        return {
+            inputChars: this.toNullableNumber(textUsage["input_chars"]),
+            outputChars: this.toNullableNumber(textUsage["output_chars"]),
+        };
+    }
+
+    private buildCacheUsage(
+        cacheUsage: Record<string, unknown>,
+    ): CacheUsageBreakdown {
+        return {
+            llmCallsSaved: this.toNumber(cacheUsage["llm_calls_saved"]),
+            llmCallsAdded: this.toNumber(cacheUsage["llm_calls_added"]),
+        };
+    }
+
     private normalizeRow(row: PersistedModelUsageRow): ModelUsageRecord {
         const payload = this.asObject(row.payload);
         const modelUsage = this.asObject(payload["model_usage"]);
         const promptUsage = this.asObject(payload["prompt_usage"]);
+        const latencyUsage = this.asObject(payload["latency_usage"]);
+        const audioUsage = this.asObject(payload["audio_usage"]);
+        const textUsage = this.asObject(payload["text_usage"]);
+        const cacheUsage = this.asObject(payload["cache_usage"]);
 
         const normalizedPromptUsage: PromptUsageBreakdown = {
             systemChars: this.toNumber(promptUsage["system_chars"]),
@@ -265,6 +337,10 @@ export class ModelUsageService implements OnDestroy {
             ),
             tokenUsage: this.buildTokenUsage(modelUsage),
             promptUsage: normalizedPromptUsage,
+            latencyUsage: this.buildLatencyUsage(latencyUsage),
+            audioUsage: this.buildAudioUsage(audioUsage),
+            textUsage: this.buildTextUsage(textUsage),
+            cacheUsage: this.buildCacheUsage(cacheUsage),
             raw: payload,
         };
     }
@@ -278,6 +354,10 @@ export class ModelUsageService implements OnDestroy {
 
     private toNumber(value: unknown): number {
         return typeof value === "number" && Number.isFinite(value) ? value : 0;
+    }
+
+    private toNullableNumber(value: unknown): number | null {
+        return typeof value === "number" && Number.isFinite(value) ? value : null;
     }
 
     private toString(value: unknown, fallback: string): string {


### PR DESCRIPTION
## Summary
- add persisted latency, audio, text, and action-cache usage metrics across LLM, STT, and TTS usage logging
- extend the model usage analytics pipeline and UI to normalize mixed usage kinds while keeping token and prompt breakdowns focused on LLM activity
- surface cache-hit savings, verification overhead, and richer recent-call metrics in the analytics view

## Testing
- pytest test/lib/test_Logger.py
- pytest test/lib/test_Database.py
- python -m py_compile src/lib/Logger.py src/lib/Models.py src/lib/STT.py src/lib/TTS.py src/lib/Assistant.py src/Chat.py
- npm run build