### PR TITLE
fix: surface assistant startup failures

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -318,8 +318,19 @@ function resolveReadableAssetPath(filePath) {
 class BackendService {
   #currentProcess = null;
   #windows = [];
+  #stopRequestedPid = null;
+  #beforeQuitRegistered = false;
+  #appQuitting = false;
+  #notifyWindows(channel, payload) {
+    for (const window of this.#windows) {
+      window.webContents.send(channel, { payload });
+    }
+  }
+  #hasActiveProcess() {
+    return Boolean(this.#currentProcess && this.#currentProcess.exitCode === null && this.#currentProcess.signalCode === null);
+  }
   sendJsonLine(event, {jsonLine}) {
-    if (!this.#currentProcess || this.#currentProcess.killed) {
+    if (!this.#hasActiveProcess()) {
       throw new Error('No active process to send JSON line to');
     }
     logger.info('[stdin]', jsonLine);
@@ -334,13 +345,14 @@ class BackendService {
   }
   startProcess(mainWindow) {
     this.attachWindow(mainWindow);
-    if (this.#currentProcess && !this.#currentProcess.killed) {
+    if (this.#hasActiveProcess()) {
       logger.warn('Process is already running, stopping it first');
+      this.#stopRequestedPid = this.#currentProcess.pid ?? null;
       this.#currentProcess.kill('SIGINT');
     }
     logger.info('Starting process:', config.backend);
 
-    this.#currentProcess = spawn(config.backend, config.backend_args, {
+    const childProcess = spawn(config.backend, config.backend_args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: config.backend_cwd,
       env: {
@@ -349,17 +361,63 @@ class BackendService {
         PYTHONUNBUFFERED: 1,
       }
     });
-    logger.info('Process started with PID:', this.#currentProcess.pid);
+    this.#currentProcess = childProcess;
+    logger.info('Process started with PID:', childProcess.pid);
 
-    app.on('before-quit', () => {
-      if (this.#currentProcess && !this.#currentProcess.killed) {
-        this.#currentProcess.kill('SIGINT');
+    if (!this.#beforeQuitRegistered) {
+      app.on('before-quit', () => {
+        this.#appQuitting = true;
+        if (this.#hasActiveProcess()) {
+          this.#stopRequestedPid = this.#currentProcess.pid ?? null;
+          this.#currentProcess.kill('SIGINT');
+        }
+      });
+      this.#beforeQuitRegistered = true;
+    }
+
+    let terminationNotified = false;
+    const notifyTermination = (payload) => {
+      if (terminationNotified) {
+        return;
       }
+      terminationNotified = true;
+
+      const expected = this.#stopRequestedPid === childProcess.pid || this.#appQuitting;
+      if (expected && this.#stopRequestedPid === childProcess.pid) {
+        this.#stopRequestedPid = null;
+      }
+      if (this.#currentProcess === childProcess) {
+        this.#currentProcess = null;
+      }
+
+      this.#notifyWindows('backend-lifecycle', {
+        ...payload,
+        expected,
+        pid: childProcess.pid ?? null,
+        timestamp: new Date().toISOString(),
+      });
+    };
+
+    childProcess.once('error', (error) => {
+      logger.error('Backend process failed:', error);
+      notifyTermination({
+        status: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      });
     });
 
-    this.#currentProcess.stdout.setEncoding('utf8');
+    childProcess.once('close', (code, signal) => {
+      logger.info('Backend process closed:', { pid: childProcess.pid, code, signal });
+      notifyTermination({
+        status: 'exited',
+        code,
+        signal,
+      });
+    });
+
+    childProcess.stdout.setEncoding('utf8');
     let partialStdout = '';
-    this.#currentProcess.stdout.on('data', (data) => {
+    childProcess.stdout.on('data', (data) => {
       if (!data) return;
       data = partialStdout + data;
       partialStdout = '';
@@ -383,9 +441,9 @@ class BackendService {
       }
     });
 
-    this.#currentProcess.stderr.setEncoding('utf8');
+    childProcess.stderr.setEncoding('utf8');
     let partialStderr = '';
-    this.#currentProcess.stderr.on('data', (data) => {
+    childProcess.stderr.on('data', (data) => {
       if (!data) return;
       data = partialStderr + data;
       partialStderr = '';
@@ -408,18 +466,19 @@ class BackendService {
         }
       }
     });
+
     mainWindow.on('close', () => {
       this.stopProcess(mainWindow);
       // remove all stdin and stdout listeners
-      this.#currentProcess.stdout.removeAllListeners('data');
-      this.#currentProcess.stderr.removeAllListeners('data');
+      childProcess.stdout.removeAllListeners('data');
+      childProcess.stderr.removeAllListeners('data');
     });
   }
   stopProcess(mainWindow) {
     this.detachWindow(mainWindow);
-    if (this.#currentProcess && !this.#currentProcess.killed) {
+    if (this.#hasActiveProcess()) {
       logger.info('Stopping process:', this.#currentProcess.pid);
-      const pid = this.#currentProcess.pid;
+      this.#stopRequestedPid = this.#currentProcess.pid ?? null;
       this.#currentProcess.kill('SIGINT');
     }
   } 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -2,6 +2,7 @@ const { contextBridge, ipcRenderer } = require('electron/renderer');
 
 let stdoutCallback = null;
 let stderrCallback = null;
+let backendLifecycleCallback = null;
 let windowCloseCallback = [];
 
 ipcRenderer.on('stdout', (_event, value) => {
@@ -18,6 +19,13 @@ ipcRenderer.on('stderr', (_event, value) => {
     console.warn('No stderr callback set, received:', value);
   }
 });
+ipcRenderer.on('backend-lifecycle', (_event, value) => {
+  if (backendLifecycleCallback) {
+    backendLifecycleCallback(value);
+  } else {
+    console.warn('No backend lifecycle callback set, received:', value);
+  }
+});
 ipcRenderer.on('window-close', (e) => {
   windowCloseCallback.forEach(callback => callback(e));
 });
@@ -25,6 +33,7 @@ ipcRenderer.on('window-close', (e) => {
 contextBridge.exposeInMainWorld('electronAPI', {
   onStdout: (callback) => stdoutCallback = callback,
   onStderr: (callback) => stderrCallback = callback,
+  onBackendLifecycle: (callback) => backendLifecycleCallback = callback,
   onWindowClose: (callback) => windowCloseCallback.push(callback),
   confirmWindowClose: () => ipcRenderer.invoke('window-close-ready'),
   userAssets: {

--- a/src/Chat.py
+++ b/src/Chat.py
@@ -1081,6 +1081,7 @@ def check_zombie_status():
 
 
 if __name__ == "__main__":
+    startup_phase = "bootstrap"
     try:
         configure_stdio()
         sys.stdin = io.TextIOWrapper(
@@ -1088,11 +1089,13 @@ if __name__ == "__main__":
         )
         emit_message("ready")
         # Wait for start signal on stdin
+        startup_phase = "config_load"
         config = load_config()
         emit_message("config", config=config)
         system = get_system_info()
         emit_message("system", system=system)
 
+        startup_phase = "plugin_load"
         ed_keys = EDKeys(
             get_ed_appdata_path(config),
             prefer_primary_bindings=config.get("prefer_primary_bindings", False),
@@ -1105,6 +1108,7 @@ if __name__ == "__main__":
         plugin_manager.register_settings()
         quest_catalog_manager = QuestCatalogManager()
         model_usage_store = ModelUsageStore()
+        startup_phase = "waiting_for_start_signal"
         while True:
             # print(f"Waiting for command...")
             line = sys.stdin.readline().strip()
@@ -1200,6 +1204,7 @@ if __name__ == "__main__":
         plugin_manager.on_settings_changed(config)
         emit_message("start")
 
+        startup_phase = "assistant_initialization"
         chat = Chat(config, plugin_manager)
         # run chat in a thread
         stdin_thread = threading.Thread(target=read_stdin, args=(chat,), daemon=True)
@@ -1212,7 +1217,19 @@ if __name__ == "__main__":
             zombie_check_thread.start()
 
         log("debug", "Running chat...")
+        startup_phase = "running"
         chat.run()
     except Exception as e:
-        log("error", e, traceback.format_exc())
+        details = traceback.format_exc()
+        if startup_phase != "running":
+            try:
+                emit_message(
+                    "startup_error",
+                    phase=startup_phase,
+                    message=str(e),
+                    details=details,
+                )
+            except Exception:
+                pass
+        log("error", e, details)
         sys.exit(1)

--- a/ui/src/app/app.config.ts
+++ b/ui/src/app/app.config.ts
@@ -5,6 +5,7 @@ import { routes } from "./app.routes";
 import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { provideHttpClient } from "@angular/common/http";
 import { MAT_DIALOG_DEFAULT_OPTIONS, MatDialogModule } from "@angular/material/dialog";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { importProvidersFrom } from "@angular/core";
 import { MarkdownModule } from 'ngx-markdown';
 import { AvatarMigrationService } from "./services/avatar-migration.service";
@@ -15,6 +16,7 @@ export const appConfig: ApplicationConfig = {
     provideAnimationsAsync(),
     provideHttpClient(),
     importProvidersFrom(MatDialogModule),
+    importProvidersFrom(MatSnackBarModule),
     importProvidersFrom(MarkdownModule.forRoot()),
     {
       provide: APP_INITIALIZER,

--- a/ui/src/app/main-view/main-view.component.html
+++ b/ui/src/app/main-view/main-view.component.html
@@ -3,7 +3,7 @@
 }
 
 <main class="app" [class.red]="isInCombat">
-    @if (!isRunning) {
+    @if (!showRuntimeView) {
         <div class="settings-container">
             <app-settings-menu (questEditorVisibilityChange)="onQuestEditorVisibilityChange($event)"></app-settings-menu>
         </div>
@@ -94,7 +94,7 @@
     }
 
     <div class="floating-action-container" [style.display]="isQuestEditorOpen ? 'none' : 'flex'">
-        @if (!isRunning) {
+        @if (!showRuntimeView) {
             @if (isLoading) {
                 <button mat-fab color="primary" aria-label="Starting" [disabled]="true">
                     <mat-icon>hourglass_empty</mat-icon>

--- a/ui/src/app/main-view/main-view.component.ts
+++ b/ui/src/app/main-view/main-view.component.ts
@@ -54,8 +54,10 @@ import {UIService} from "../services/ui.service";
 export class MainViewComponent implements OnInit, OnDestroy {
     @ViewChild(SettingsMenuComponent) private settingsMenu?: SettingsMenuComponent;
 
+    runMode: "starting" | "configuring" | "running" | "error" = "starting";
     isLoading = true;
     isRunning = false;
+    showRuntimeView = false;
     isInCombat = false;
     isDockedAtStation = false;
     isShipIdentUnknown = false;
@@ -108,8 +110,13 @@ export class MainViewComponent implements OnInit, OnDestroy {
         // Subscribe to the running state
         this.tauri.runMode$.subscribe(
             (mode) => {
+                this.runMode = mode;
                 this.isRunning = mode === "running";
                 this.isLoading = mode === "starting";
+                this.showRuntimeView = mode === "running" || mode === "error";
+                if (mode === "error") {
+                    this.selectedTabIndex = 0;
+                }
             },
         );
 

--- a/ui/src/app/services/pngtuber.service.ts
+++ b/ui/src/app/services/pngtuber.service.ts
@@ -80,7 +80,10 @@ export class PngTuberService {
             }
         )
         this.chatService.chatHistory$.subscribe((chat)=>{
-            const preview = chat.filter(value => ['covas', 'cmdr', 'action', 'npc_message'].includes(value.role)).slice(-2)
+            const preview = chat.filter(
+                (value) => value["show_in_overlay"] !== false
+                    && ['covas', 'cmdr', 'action', 'npc_message'].includes(value.role),
+            ).slice(-2)
             this.chatPreviewSubject.next(preview)
         })
         this.chatService.chatMessage$.subscribe((msg)=>{

--- a/ui/src/app/services/tauri.service.ts
+++ b/ui/src/app/services/tauri.service.ts
@@ -2,6 +2,7 @@
 import { Injectable, NgZone } from "@angular/core";
 //import { invoke } from "@tauri-apps/api/core";
 import { type UnlistenFn } from "@tauri-apps/api/event";
+import { MatSnackBar } from "@angular/material/snack-bar";
 import { BehaviorSubject, Observable, ReplaySubject } from "rxjs";
 import { MatDialog } from "@angular/material/dialog";
 import { UpdateDialogComponent } from "../components/update-dialog/update-dialog.component";
@@ -14,6 +15,7 @@ declare global {
             invoke: (call: string, opts?: any) => Promise<any>;
             onStdout: (callback: (value: any) => void) => Promise<void> | void;
             onStderr: (callback: (value: any) => void) => Promise<void> | void;
+            onBackendLifecycle: (callback: (value: any) => void) => Promise<void> | void;
             onWindowClose: (callback: (event: Event) => void) => void;
             confirmWindowClose: () => Promise<void>;
             userAssets?: {
@@ -38,6 +40,29 @@ export interface BaseMessage {
     timestamp: string;
     index: number;
     [key: string]: any;
+}
+
+type OutboundMessage = {
+    type: string;
+    timestamp: string;
+    [key: string]: any;
+};
+
+export interface StartupErrorMessage extends BaseMessage {
+    type: "startup_error";
+    phase: string;
+    message: string;
+    details?: string;
+}
+
+export interface BackendLifecycleMessage extends BaseMessage {
+    type: "backend_process_state";
+    status: "exited" | "error";
+    expected: boolean;
+    pid: number | null;
+    code?: number | null;
+    signal?: string | null;
+    message?: string;
 }
 
 export interface OverlayCreateOptions {
@@ -150,7 +175,7 @@ export class TauriService {
     public readonly commitHash = environment.COMMIT_HASH;
     public readonly windowCloseCallbacks = [] as ((event: Event) => void)[];
     private runModeSubject = new BehaviorSubject<
-        "starting" | "configuring" | "running"
+        "starting" | "configuring" | "running" | "error"
     >(
         "starting",
     );
@@ -168,8 +193,14 @@ export class TauriService {
     private stopStderrListener?: UnlistenFn;
 
     private currentIndex = 0;
+    private startupErrorPendingExit = false;
+    private restartTimer: number | null = null;
 
-    constructor(private ngZone: NgZone, private dialog: MatDialog) {
+    constructor(
+        private ngZone: NgZone,
+        private dialog: MatDialog,
+        private snackBar: MatSnackBar,
+    ) {
         this.startReadingOutput();
         window.localStorage.setItem("install_id", this.installId);
 
@@ -227,6 +258,90 @@ export class TauriService {
         await electronAPI.onStderr(
             (e) => this.processStderr(e),
         );
+        await electronAPI.onBackendLifecycle(
+            (e) => this.processBackendLifecycle(e),
+        );
+    }
+
+    private pushMessage(message: OutboundMessage): void {
+        const nextMessage: BaseMessage = {
+            ...message,
+            index: this.currentIndex++,
+        };
+        this.messagesSubject.next(nextMessage);
+    }
+
+    private pushLog(message: string, prefix: "debug" | "info" | "warn" | "error" = "error"): void {
+        this.pushMessage({
+            type: "log",
+            timestamp: new Date().toISOString(),
+            message,
+            prefix,
+        });
+    }
+
+    private isOverlayWindow(): boolean {
+        return window.location.hash.startsWith("#/overlay");
+    }
+
+    private showErrorToast(message: string): void {
+        if (this.isOverlayWindow()) {
+            return;
+        }
+        this.snackBar.open(message, "Dismiss", {
+            duration: 15000,
+            panelClass: ["validation-error-snackbar"],
+        });
+    }
+
+    private scheduleBackendRestart(): void {
+        if (this.isOverlayWindow() || this.restartTimer !== null) {
+            return;
+        }
+
+        this.runModeSubject.next("starting");
+        this.restartTimer = window.setTimeout(async () => {
+            this.restartTimer = null;
+            try {
+                await this.runExe();
+            } catch (error) {
+                console.error("Scheduled backend restart failed:", error);
+            }
+        }, 3000);
+    }
+
+    private handleStartupError(message: StartupErrorMessage): void {
+        const currentMode = this.runModeSubject.getValue();
+        const shouldStayInConfig = currentMode === "starting" || currentMode === "configuring";
+
+        if (!shouldStayInConfig) {
+            this.runModeSubject.next("error");
+        }
+        this.startupErrorPendingExit = true;
+
+        const phase = message.phase || "startup";
+        const summary = message.message?.trim() || "Unknown startup error";
+        const details = message.details?.trim();
+        const detailLine = details
+            ?.split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .at(-1);
+
+        this.pushLog(`Assistant startup failed during ${phase}: ${summary}`);
+        if (details && details !== summary) {
+            this.pushLog(details);
+        }
+
+        if (!shouldStayInConfig) {
+            this.pushMessage({
+                type: "chat",
+                timestamp: message.timestamp || new Date().toISOString(),
+                role: "error",
+                message: `Assistant startup failed during ${phase}: ${detailLine || summary}`,
+                show_in_overlay: false,
+            });
+        }
     }
 
     private processStdout(event: any): void {
@@ -247,24 +362,86 @@ export class TauriService {
                 if (message.type === "config") {
                     this.runModeSubject.next("configuring");
                 }
-                this.messagesSubject.next({
-                    ...message,
-                    index: this.currentIndex++,
-                });
+                if (message.type === "startup_error") {
+                    this.handleStartupError(message as StartupErrorMessage);
+                }
+                this.pushMessage(message);
             } catch (error) {
                 console.warn("Error parsing message:", error, event);
             }
         });
     }
 
+    private processBackendLifecycle(event: any): void {
+        this.ngZone.run(() => {
+            const payload = event?.payload ?? {};
+            const previousMode = this.runModeSubject.getValue();
+            const message: BackendLifecycleMessage = {
+                type: "backend_process_state",
+                timestamp: payload.timestamp || new Date().toISOString(),
+                status: payload.status === "error" ? "error" : "exited",
+                expected: Boolean(payload.expected),
+                pid: typeof payload.pid === "number" ? payload.pid : null,
+                code: payload.code ?? null,
+                signal: payload.signal ?? null,
+                message: typeof payload.message === "string" ? payload.message : undefined,
+                index: this.currentIndex,
+            };
+
+            this.pushMessage(message);
+
+            if (message.expected) {
+                this.startupErrorPendingExit = false;
+                return;
+            }
+
+            const exitedDuringConfig = previousMode === "starting" || previousMode === "configuring";
+            if (this.startupErrorPendingExit) {
+                this.startupErrorPendingExit = false;
+                if (!exitedDuringConfig) {
+                    return;
+                }
+            }
+
+            const shouldToast = exitedDuringConfig;
+
+            if (exitedDuringConfig) {
+                this.scheduleBackendRestart();
+            } else {
+                this.runModeSubject.next("error");
+            }
+
+            if (message.status === "error") {
+                const details = message.message || "Unknown backend error";
+                this.pushLog(`Assistant process failed to start: ${details}`);
+                if (shouldToast) {
+                    this.showErrorToast(`Assistant process failed to start: ${details}`);
+                }
+                return;
+            }
+
+            const exitDetails = [
+                message.code !== null && message.code !== undefined ? `code ${message.code}` : null,
+                message.signal ? `signal ${message.signal}` : null,
+            ].filter(Boolean).join(", ");
+            const exitMessage = exitDetails
+                ? `Assistant process exited unexpectedly (${exitDetails}).`
+                : "Assistant process exited unexpectedly.";
+
+            this.pushLog(exitMessage);
+            if (shouldToast) {
+                this.showErrorToast(exitMessage);
+            }
+        });
+    }
+
     private processStderr(event: any): void {
         this.ngZone.run(() => {
-            this.messagesSubject.next({
+            this.pushMessage({
                 type: "log",
                 timestamp: new Date().toISOString(),
                 message: event.payload,
                 prefix: "error",
-                index: this.currentIndex++,
             });
         });
     }
@@ -275,14 +452,15 @@ export class TauriService {
     }
 
     public async runExe(): Promise<string[]> {
-        this.stopExe();
+        await this.stopExe();
         try {
             const output: string[] = await electronAPI.invoke("start_process", {});
             this.startReadingOutput();
             return output;
         } catch (error) {
             console.error("Error running exe:", error);
-            alert(
+            this.runModeSubject.next("error");
+            this.showErrorToast(
                 `Error starting subprocess: ${
                     error instanceof Error ? error.message : error
                 }`,
@@ -305,6 +483,9 @@ export class TauriService {
         await this.runExe();
     }
     public async send_start_signal(): Promise<void> {
+        if (this.runModeSubject.getValue() === "error") {
+            await this.runExe();
+        }
         await this.send_command({
             type: "start",
             timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- add backend lifecycle monitoring between Electron and the Angular UI so unexpected Python exits are surfaced correctly
- emit structured startup errors from Python and keep them visible in the main app while suppressing overlay toasts and overlay error chat
- keep config-mode crashes in the settings view, show a toast in the main window, and auto-restart the backend after a short delay

## Verification
- node --check electron/index.js
- node --check electron/preload.js
- python -m py_compile src/Chat.py
- npm run build