### PR TITLE
fix: show web search errors in search tab

### DIFF
--- a/ui/src/app/components/search-results-container/search-results-container.component.html
+++ b/ui/src/app/components/search-results-container/search-results-container.component.html
@@ -25,7 +25,12 @@
   </div>
 
   <div class="results-content">
-    @if (searchResult) {
+    @if (searchError) {
+      <div class="search-error">
+        <div class="search-error-title">Search failed</div>
+        <pre>{{ searchError }}</pre>
+      </div>
+    } @else if (searchResult) {
       <markdown [data]="searchResult"></markdown>
     } @else {
       <div class="no-results">No search results available yet.</div>

--- a/ui/src/app/components/search-results-container/search-results-container.component.scss
+++ b/ui/src/app/components/search-results-container/search-results-container.component.scss
@@ -123,6 +123,26 @@
   font-style: italic;
 }
 
+.search-error {
+  color: #ff8a80;
+
+  pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: monospace;
+    background: rgba(255, 82, 82, 0.08);
+    border: 1px solid rgba(255, 82, 82, 0.2);
+    border-radius: 4px;
+    padding: 0.75rem;
+  }
+}
+
+.search-error-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
 .results-footer {
   text-align: right;
 }

--- a/ui/src/app/components/search-results-container/search-results-container.component.ts
+++ b/ui/src/app/components/search-results-container/search-results-container.component.ts
@@ -7,7 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { ChatService } from "../../services/chat.service";
+import { ChatMessage, ChatService } from "../../services/chat.service";
 import { TauriService } from "../../services/tauri.service";
 import { Subscription } from "rxjs";
 import { MarkdownModule } from 'ngx-markdown';
@@ -32,21 +32,45 @@ import { MarkdownModule } from 'ngx-markdown';
 export class SearchResultsComponent implements OnInit, OnDestroy {
   searchQuery: string = "";
   searchResult: string | null = null;
+  searchError: string | null = null;
   isLoading: boolean = false;
   private searchResultSubscription: Subscription | null = null;
+  private errorMessageSubscription: Subscription | null = null;
 
   constructor(private chatService: ChatService, private tauriService: TauriService) {}
 
   ngOnInit(): void {
     this.searchResultSubscription = this.chatService.searchResult$.subscribe(result => {
-      if (result) {
-        this.isLoading = false;
-        if (result.content && typeof result.content === 'string') {
-            this.searchResult = result.content;
-        } else {
-            this.searchResult = JSON.stringify(result, null, 2);
-        }
+      if (!result) {
+        return;
       }
+
+      this.isLoading = false;
+      this.searchError = null;
+
+      if (result.content && typeof result.content === 'string') {
+        const content = result.content.trim();
+        if (this.isSearchError(content)) {
+          this.searchResult = null;
+          this.searchError = content;
+          return;
+        }
+
+        this.searchResult = content;
+        return;
+      }
+
+      this.searchResult = JSON.stringify(result, null, 2);
+    });
+
+    this.errorMessageSubscription = this.chatService.chatMessage$.subscribe((message: ChatMessage | null) => {
+      if (!this.isLoading || !message || message.role?.toLowerCase() !== 'error') {
+        return;
+      }
+
+      this.isLoading = false;
+      this.searchResult = null;
+      this.searchError = message.message || 'An unknown search error occurred.';
     });
   }
 
@@ -54,16 +78,25 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
     if (this.searchResultSubscription) {
       this.searchResultSubscription.unsubscribe();
     }
+    if (this.errorMessageSubscription) {
+      this.errorMessageSubscription.unsubscribe();
+    }
   }
 
   search(): void {
     if (!this.searchQuery.trim()) return;
     
     this.isLoading = true;
+    this.searchResult = null;
+    this.searchError = null;
     this.tauriService.send_command({
       type: "web_search",
       query: this.searchQuery,
       timestamp: new Date().toISOString()
     });
+  }
+
+  private isSearchError(content: string): boolean {
+    return /^(error|llm error)\s*:/i.test(content);
   }
 }


### PR DESCRIPTION
## Summary
- surface web search execution failures directly in the Search tab instead of leaving the panel blank
- detect error-shaped tool output and backend error chat events while a search is in flight
- add a dedicated error state in the search results UI and keep stale results cleared between searches

## Testing
- npm run build