### PR TITLE
fix: handle platform-specific startup errors

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -330,11 +330,23 @@ class BackendService {
     return Boolean(this.#currentProcess && this.#currentProcess.exitCode === null && this.#currentProcess.signalCode === null);
   }
   sendJsonLine(event, {jsonLine}) {
-    if (!this.#hasActiveProcess()) {
+    const childProcess = this.#currentProcess;
+    if (!this.#hasActiveProcess() || !childProcess?.stdin?.writable) {
       throw new Error('No active process to send JSON line to');
     }
     logger.info('[stdin]', jsonLine);
-    this.#currentProcess.stdin.write(jsonLine + '\n');
+    try {
+      const written = childProcess.stdin.write(jsonLine + '\n');
+      if (!written && childProcess.stdin.destroyed) {
+        throw new Error('Backend stdin is closed');
+      }
+    } catch (error) {
+      logger.warn('Failed to write to backend stdin:', error);
+      if (this.#currentProcess === childProcess) {
+        this.#currentProcess = null;
+      }
+      throw new Error('Backend process is no longer accepting input');
+    }
     return true;
   }
   attachWindow(subWindow) {
@@ -413,6 +425,10 @@ class BackendService {
         code,
         signal,
       });
+    });
+
+    childProcess.stdin.once('error', (error) => {
+      logger.warn('Backend stdin failed:', error);
     });
 
     childProcess.stdout.setEncoding('utf8');

--- a/src/lib/ControllerManager.py
+++ b/src/lib/ControllerManager.py
@@ -95,6 +95,7 @@ class ControllerManager:
         if self.joystick_hotkeys_supported:
             for _event in pygame.event.get():
                 pass
+        self._prepare_macos_accessibility_check()
 
         def on_key_press(key):
             on_press(str(key))
@@ -137,6 +138,16 @@ class ControllerManager:
             self.joystick_listener_running = True
             self.joystick_listener = threading.Thread(target=capture_event, daemon=True)
             self.joystick_listener.start()
+
+    def _prepare_macos_accessibility_check(self):
+        if platform.system() != "Darwin":
+            return
+
+        try:
+            import HIServices
+            getattr(HIServices, "AXIsProcessTrusted")
+        except Exception as e:
+            logger.warning(f"Unable to prepare macOS accessibility check: {e}")
 
     def _stop_listeners(self):
         # Stop existing listeners


### PR DESCRIPTION
## Summary
- Handle backend stdin `EPIPE`/closed-pipe failures without surfacing uncaught Electron main-process exceptions on Windows.
- Warm up the macOS AXI trust symbol lookup before listener setup and log failures instead of letting them interrupt startup.

## Validation
- `node --check electron/index.js`
- `python -m py_compile src/lib/ControllerManager.py`