### PR TITLE
Add station finder market filters

### DIFF
--- a/docs/20_actions.md
+++ b/docs/20_actions.md
@@ -1325,14 +1325,16 @@ These call external services or game APIs (Galnet, Spansh):
     - `name`: require text in the station name.
     - `distance`: maximum search radius.
     - `has_large_pad`: only include stations with large pads.
+    - `include_planetary_stations`: include planetary stations. Defaults to `true`; set to `false` to return only non-planetary stations.
     - `material_trader`: look for Raw, Manufactured, or Encoded material traders.
     - `technology_broker`: look for Human or Guardian tech brokers.
     - `modules`: search for specific outfitting items; can further narrow by class and rating.
     - `commodities`: search for markets buying or selling a named commodity, with requested amount.
+    - `market_days_old`: maximum age in days for commodity market data. Used only with `commodities` and defaults to `2`; results state the effective limit.
     - `ships`: search for shipyards stocking a named ship.
     - `services`: look for special services such as Black Market or Interstellar Factors.
     - `sort_by`: order results by distance or best price.
-    - `include_player_fleetcarrier`: include player-owned carriers in the results.
+    - `include_player_fleetcarrier`: include player-owned Drake-Class Carriers in the results. Defaults to `false`.
     - `unfiltered_results`: return full commodity/module/ship data instead of only the matched entries.
     - `size`: number of results to return.
 

--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -869,6 +869,7 @@ class Config(TypedDict):
     cn_autostart: bool
     ed_journal_path: str
     ed_appdata_path: str
+    linux_edcp: bool
     qol_autobrake: bool  # Quality of life: Auto brake when approaching stations
     qol_autoscan: bool  # Quality of life: Auto scan when entering new systems
     prefer_primary_bindings: bool  # Prefer primary keybinds over secondary entries
@@ -1417,6 +1418,7 @@ def load_config() -> Config:
         'embedding_api_key': "",
         "ed_journal_path": "",
         "ed_appdata_path": "",
+        "linux_edcp": False,
         "qol_autobrake": False,  # Quality of life: Auto brake when approaching stations
         "qol_autoscan": False,  # Quality of life: Auto scan when entering new systems
 

--- a/src/lib/EventModels.py
+++ b/src/lib/EventModels.py
@@ -2080,10 +2080,17 @@ class SearchAndRescueEvent(TypedDict):
     Count: int
 
 
-# Died: 744 characters, 8 entries
+# Died: player was killed, optionally by a wing
+class DiedEventKiller(TypedDict):
+    Name: str
+    Ship: str
+    Rank: str
+
+
 class DiedEvent(TypedDict):
     KillerShip: NotRequired[str]
     KillerName: NotRequired[Literal["Elvis Sims"]]
+    Killers: NotRequired[list[DiedEventKiller]]
     event: Literal["Died"]
     timestamp: str
     KillerRank: NotRequired[str]

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -128,7 +128,7 @@ class PromptGenerator:
         depth = pad['depth']
         return f"{clock} o'clock, {depth} (Pad {pad_number}, clock orientation: mail slot entry with green on right)"
 
-    def get_event_template(self, event: Union[GameEvent, ProjectedEvent, ExternalEvent, QuestEvent]):
+    def get_event_template(self, event: Union[GameEvent, ProjectedEvent, ExternalEvent, QuestEvent], projected_states: ProjectedStates | None = None):
         content: Any = event.content
         event_name = content.get('event')
         
@@ -2029,13 +2029,25 @@ class PromptGenerator:
                 ship_name = ship_targeted_event.get('Ship_Localised', ship_targeted_event.get('Ship', 'ship'))
                 legal_status = ship_targeted_event.get('LegalStatus', '')
                 commander_name = pilot_name.partition('$cmdr_decorate:#name=')[2].partition(';')[0]
+                local_commander_name = get_state_dict(projected_states, 'Commander').get('Name', '') if projected_states else ''
+                is_own_ship = bool(commander_name) and commander_name.casefold() == local_commander_name.casefold()
                 target_description = None
                 if pilot_name.startswith('$RolePanel2_unmanned;') and commander_name:
-                    target_description = f"{legal_status} unmanned {ship_name} belonging to CMDR {commander_name}"
+                    target_description = (
+                        f"your unmanned main ship, {ship_name}"
+                        if is_own_ship else f"{legal_status} unmanned {ship_name} belonging to CMDR {commander_name}"
+                    )
                 elif pilot_name.startswith('$RolePanel2_crew;') and commander_name:
-                    target_description = f"{legal_status} {ship_name} steered by CMDR {commander_name}'s NPC crew"
+                    target_description = (
+                        f"your main ship, {ship_name}, steered by your NPC crew"
+                        if is_own_ship else f"{legal_status} {ship_name} steered by CMDR {commander_name}'s NPC crew"
+                    )
                 if target_description:
                     if ship_targeted_event.get('Subsystem_Localised'):
+                        if is_own_ship and pilot_name.startswith('$RolePanel2_unmanned;'):
+                            return f"Weapons now targeting your unmanned main ship's {ship_targeted_event.get('Subsystem_Localised')}"
+                        if is_own_ship:
+                            return f"Weapons now targeting your main ship's {ship_targeted_event.get('Subsystem_Localised')}, operated by your NPC crew"
                         return f"Weapons now targeting {target_description}'s {ship_targeted_event.get('Subsystem_Localised')}"
                     return f"Sensors and weapons locked on to {target_description}"
                 if ship_targeted_event.get('Subsystem_Localised'):
@@ -2452,8 +2464,8 @@ class PromptGenerator:
 
         return None
 
-    def event_message(self, event: Union[GameEvent, ProjectedEvent, ExternalEvent, QuestEvent], timeoffset: str, is_important: bool):
-        message = self.get_event_template(event)
+    def event_message(self, event: Union[GameEvent, ProjectedEvent, ExternalEvent, QuestEvent], timeoffset: str, is_important: bool, projected_states: ProjectedStates | None = None):
+        message = self.get_event_template(event, projected_states)
         if message:
             return {
                 "role": "user",
@@ -3654,7 +3666,7 @@ class PromptGenerator:
 
                 if len(conversational_pieces) < 20:
                     is_important = is_pending and event_type in self.important_game_events
-                    message = self.event_message(event, time_offset, is_important)
+                    message = self.event_message(event, time_offset, is_important, projected_states)
                     if message:
                         piece = message
                         conversational_pieces.append(piece)

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -2026,24 +2026,22 @@ class PromptGenerator:
             ship_targeted_event = cast(ShipTargetedEvent, content)
             if ship_targeted_event.get('TargetLocked'):
                 pilot_name = ship_targeted_event.get('PilotName', '')
-                pilot_name_localised = ship_targeted_event.get('PilotName_Localised', '')
                 ship_name = ship_targeted_event.get('Ship_Localised', ship_targeted_event.get('Ship', 'ship'))
                 legal_status = ship_targeted_event.get('LegalStatus', '')
+                commander_name = pilot_name.partition('$cmdr_decorate:#name=')[2].partition(';')[0]
                 target_description = None
-                if pilot_name.startswith('$RolePanel2_unmanned;') and pilot_name_localised.startswith('unmanned '):
-                    commander_name = pilot_name_localised.removeprefix('unmanned ')
-                    target_description = f"{legal_status} unmanned {ship_name} belonging to {commander_name}"
-                elif pilot_name.startswith('$RolePanel2_crew;') and pilot_name_localised.startswith('Crew '):
-                    commander_name = pilot_name_localised.removeprefix('Crew ')
-                    target_description = f"{legal_status} {ship_name} steered by {commander_name}'s NPC crew"
+                if pilot_name.startswith('$RolePanel2_unmanned;') and commander_name:
+                    target_description = f"{legal_status} unmanned {ship_name} belonging to CMDR {commander_name}"
+                elif pilot_name.startswith('$RolePanel2_crew;') and commander_name:
+                    target_description = f"{legal_status} {ship_name} steered by CMDR {commander_name}'s NPC crew"
                 if target_description:
                     if ship_targeted_event.get('Subsystem_Localised'):
                         return f"Weapons now targeting {target_description}'s {ship_targeted_event.get('Subsystem_Localised')}"
                     return f"Sensors and weapons locked on to {target_description}"
                 if ship_targeted_event.get('Subsystem_Localised'):
-                    return f"Weapons now targeting {ship_targeted_event.get('LegalState', '')} pilot {ship_targeted_event.get('PilotName_Localised')}'s {ship_targeted_event.get('Subsystem_Localised')}"
+                    return f"Weapons now targeting {legal_status} pilot {ship_targeted_event.get('PilotName_Localised')}'s {ship_targeted_event.get('Subsystem_Localised')}"
                 if ship_targeted_event.get('PilotName_Localised'):
-                    return f"Sensors and weapons locked on to {ship_targeted_event.get('LegalState', '')} pilot {ship_targeted_event.get('PilotName_Localised')}'s {ship_targeted_event.get('Ship','ship').capitalize()}"
+                    return f"Sensors and weapons locked on to {legal_status} pilot {ship_targeted_event.get('PilotName_Localised')}'s {ship_targeted_event.get('Ship','ship').capitalize()}"
                 else:
                     return f"Sensors and weapons locked on to the {ship_targeted_event.get('Ship','ship').capitalize()}"
             else:

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -2106,6 +2106,13 @@ class PromptGenerator:
 
         if event_name == 'Died':
             died_event = cast(DiedEvent, content)
+            killers = died_event.get('Killers', [])
+            if killers:
+                killer_descriptions = ', '.join(
+                    f"{killer.get('Name', 'unknown killer')} ({killer.get('Ship', 'unknown ship')}, {killer.get('Rank', 'unknown rank')})"
+                    for killer in killers
+                )
+                return f"{self.commander_name} has been killed by a wing: {killer_descriptions}."
             if died_event.get('KillerName'):
                 return f"{self.commander_name} has been killed by {died_event.get('KillerName')} ({died_event.get('KillerShip', 'unknown ship')}, {died_event.get('KillerRank', 'unknown rank')})."
             return f"{self.commander_name} has been killed."

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -2025,12 +2025,27 @@ class PromptGenerator:
         if event_name == 'ShipTargeted':
             ship_targeted_event = cast(ShipTargetedEvent, content)
             if ship_targeted_event.get('TargetLocked'):
+                pilot_name = ship_targeted_event.get('PilotName', '')
+                pilot_name_localised = ship_targeted_event.get('PilotName_Localised', '')
+                ship_name = ship_targeted_event.get('Ship_Localised', ship_targeted_event.get('Ship', 'ship'))
+                legal_status = ship_targeted_event.get('LegalStatus', '')
+                target_description = None
+                if pilot_name.startswith('$RolePanel2_unmanned;') and pilot_name_localised.startswith('unmanned '):
+                    commander_name = pilot_name_localised.removeprefix('unmanned ')
+                    target_description = f"{legal_status} unmanned {ship_name} belonging to {commander_name}"
+                elif pilot_name.startswith('$RolePanel2_crew;') and pilot_name_localised.startswith('Crew '):
+                    commander_name = pilot_name_localised.removeprefix('Crew ')
+                    target_description = f"{legal_status} {ship_name} steered by {commander_name}'s NPC crew"
+                if target_description:
+                    if ship_targeted_event.get('Subsystem_Localised'):
+                        return f"Weapons now targeting {target_description}'s {ship_targeted_event.get('Subsystem_Localised')}"
+                    return f"Sensors and weapons locked on to {target_description}"
                 if ship_targeted_event.get('Subsystem_Localised'):
                     return f"Weapons now targeting {ship_targeted_event.get('LegalState', '')} pilot {ship_targeted_event.get('PilotName_Localised')}'s {ship_targeted_event.get('Subsystem_Localised')}"
                 if ship_targeted_event.get('PilotName_Localised'):
-                    return f"Weapons now targeting {ship_targeted_event.get('LegalState', '')} pilot {ship_targeted_event.get('PilotName_Localised')}'s {ship_targeted_event.get('Ship','ship').capitalize()}"
+                    return f"Sensors and weapons locked on to {ship_targeted_event.get('LegalState', '')} pilot {ship_targeted_event.get('PilotName_Localised')}'s {ship_targeted_event.get('Ship','ship').capitalize()}"
                 else:
-                    return f"Weapons now targeting the {ship_targeted_event.get('Ship','ship').capitalize()}"
+                    return f"Sensors and weapons locked on to the {ship_targeted_event.get('Ship','ship').capitalize()}"
             else:
                 return f"Weapons' target lock lost."
 

--- a/src/lib/PromptGenerator.py
+++ b/src/lib/PromptGenerator.py
@@ -2350,6 +2350,8 @@ class PromptGenerator:
         if event_name == 'LegalStateChanged':
             return f"Legal state is now {status['LegalState']}"
         if event_name == 'WeaponSelected':
+            if status['SelectedWeapon'] == '$humanoid_fists_name;':
+                return "Handheld equipment has been sheathed"
             return f"Selected weapon {status['SelectedWeapon']}"
 
         if event_name == "HudSwitchedToCombatMode":

--- a/src/lib/actions/actions_web.py
+++ b/src/lib/actions/actions_web.py
@@ -224,10 +224,12 @@ def web_search_agent(
                         "name": { "type": "string", "description": "Required string in station name" },
                         "distance": { "type": "number", "description": "The maximum distance to search in" },
                         "has_large_pad": { "type": "boolean", "description": "Filter for stations with large landing pad" },
+                        "include_planetary_stations": { "type": "boolean", "description": "Include planetary stations. Default: true." },
                         "material_trader": { "type": "array", "items": { "type": "string", "enum": ["Encoded", "Manufactured", "Raw"] } },
                         "technology_broker": { "type": "array", "items": { "type": "string", "enum": ["Guardian", "Human"] } },
                         "modules": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string" }, "class": { "type": "array", "items": { "type": "string" } }, "rating": { "type": "array", "items": { "type": "string" } } }, "required": ["name"] } },
                         "commodities": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string" }, "amount": { "type": "integer" }, "transaction": { "type": "string", "enum": ["Buy", "Sell"] } }, "required": ["name", "amount", "transaction"]} },
+                        "market_days_old": { "type": "integer", "minimum": 1, "description": "Maximum age of commodity market data in days. Used only for commodity searches. Default: 2." },
                         "ships": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string" } }, "required": ["name"] } },
                         "services": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string", "enum": ["Black Market", "Interstellar Factors Contact"] } }, "required": ["name"] } },
                         "sort_by": { "type": "string", "enum": ["distance", "bestprice"], "description": "Sort stations either by distance or best price when commodities are included. Default: bestprice." },
@@ -2010,6 +2012,8 @@ def prepare_station_request(obj, projected_states):# Helper function for fuzzy m
     requires_large_pad = ship_info.get('LandingPadSize') == 'L'
     if requires_large_pad:
         filters["has_large_pad"] = {"value": True}
+    if obj.get("include_planetary_stations") is False:
+        filters["is_planetary"] = {"value": False}
     material_trader = filter_empty_list_items(obj.get("material_trader"))
     if has_meaningful_filter_value(material_trader):
         filters["material_trader"] = {"value": material_trader}
@@ -2018,6 +2022,13 @@ def prepare_station_request(obj, projected_states):# Helper function for fuzzy m
         filters["technology_broker"] = {"value": technology_broker}
     commodities = filter_empty_list_items(obj.get("commodities"))
     if commodities:
+        market_days_old = obj.get("market_days_old", 2)
+        if isinstance(market_days_old, bool) or not isinstance(market_days_old, int) or market_days_old < 1:
+            raise Exception("market_days_old must be a positive whole number.")
+        filters["market_updated_at"] = {
+            "comparison": "<=>",
+            "value": [f"now-{market_days_old}d", "now"]
+        }
         market_filters = []
         for market_item in commodities:
             # Find matching commodity name using fuzzy matching
@@ -2183,11 +2194,15 @@ def filter_station_response(request, response, unfiltered_results=None):
 
         filtered_results.append(filtered_result)
 
-    return {
+    filtered_response = {
         "amount_total": response["count"],
         "amount_displayed": min(response["count"], response["size"]),
         "results": filtered_results
     }
+    market_updated_at = request["filters"].get("market_updated_at")
+    if market_updated_at:
+        filtered_response["market_data_max_age_days"] = int(market_updated_at["value"][0][4:-1])
+    return filtered_response
 
 
 def station_finder(obj, projected_states):

--- a/src/lib/projections/ship_info.py
+++ b/src/lib/projections/ship_info.py
@@ -15,6 +15,7 @@ from ..StatusParser import Status
 from ..EventModels import (
     CargoEvent,
     DockFighterEvent,
+    DockSRVEvent,
     FighterDestroyedEvent,
     FighterRebuiltEvent,
     JetConeBoostEvent,
@@ -292,11 +293,11 @@ class ShipInfo(Projection[ShipInfoStateModel]):
                             fighter.Pilot = pilot
                             break
 
-        if isinstance(event, GameEvent) and event.content.get("event") == "DockFighter":
-            payload = cast(DockFighterEvent, event.content)
+        if isinstance(event, GameEvent) and event.content.get("event") in ["DockFighter", "DockSRV"]:
+            payload = cast(DockFighterEvent | DockSRVEvent, event.content)
             fighter_id = payload.get("ID")
 
-            # Find fighter by ID and set to ready, clear ID
+            # Fighters launched by telepresence can be reported as DockSRV.
             for fighter in self.state.Fighters:
                 if fighter.ID == fighter_id:
                     fighter.Status = "Ready"

--- a/src/lib/projections/target.py
+++ b/src/lib/projections/target.py
@@ -53,8 +53,8 @@ class Target(Projection[TargetStateModel]):
         projected_events: list[ProjectedEvent] = []
 
         if isinstance(event, GameEvent) and event.content.get("event") in [
-            "LoadGame", "Shutdown", "Died", "ShipDestroyed",
-            "SupercruiseEntry", "Disembark", "Embark",
+            "LoadGame", "Shutdown", "Died", "DockSRV", "LaunchSRV", "SRVDestroyed",
+            "SupercruiseEntry", "Disembark", "Embark", "LaunchFighter", "DockFighter", "ShipDestroyed"
         ]:
             self._reset_state()
         if isinstance(event, GameEvent) and event.content.get("event") == "ShipTargeted":

--- a/src/lib/projections/target.py
+++ b/src/lib/projections/target.py
@@ -53,8 +53,8 @@ class Target(Projection[TargetStateModel]):
         projected_events: list[ProjectedEvent] = []
 
         if isinstance(event, GameEvent) and event.content.get("event") in [
-            "LoadGame", "Shutdown", "Died", "PVPKill", "ShipDestroyed",
-            "SupercruiseEntry", "Docked", "Embark",
+            "LoadGame", "Shutdown", "Died", "ShipDestroyed",
+            "SupercruiseEntry", "Disembark", "Embark",
         ]:
             self._reset_state()
         if isinstance(event, GameEvent) and event.content.get("event") == "ShipTargeted":

--- a/src/lib/projections/target.py
+++ b/src/lib/projections/target.py
@@ -52,7 +52,10 @@ class Target(Projection[TargetStateModel]):
     def process(self, event: Event) -> list[ProjectedEvent]:
         projected_events: list[ProjectedEvent] = []
 
-        if isinstance(event, GameEvent) and event.content.get("event") in ["LoadGame", "Shutdown"]:
+        if isinstance(event, GameEvent) and event.content.get("event") in [
+            "LoadGame", "Shutdown", "Died", "PVPKill", "ShipDestroyed",
+            "SupercruiseEntry", "Docked", "Embark",
+        ]:
             self._reset_state()
         if isinstance(event, GameEvent) and event.content.get("event") == "ShipTargeted":
             payload = cast(ShipTargetedEvent, event.content)

--- a/src/plugins/EDCoPilotPlugin.py
+++ b/src/plugins/EDCoPilotPlugin.py
@@ -17,6 +17,7 @@ from lib.PluginSettingDefinitions import (
 )
 from lib.Logger import log, show_chat_message
 from lib.PluginBase import PluginBase, PluginManifest
+from lib.Config import load_config
 
 from EDMesg.CovasNext import (
     ExternalChatNotification,
@@ -423,7 +424,12 @@ class EDCoPilotPlugin(PluginBase):
     
     def is_installed(self) -> bool:
         """Check if EDCoPilot is installed"""
-        return self.install_path is not None
+        if self.install_path is not None:
+            return True
+
+        helper = getattr(self, '_helper', None)
+        config = helper._config if helper else load_config()
+        return config.get('linux_edcp', False)
     
     def is_running(self) -> bool:
         """Check if EDCoPilot is running"""

--- a/test/lib/projections/test_ship_info.py
+++ b/test/lib/projections/test_ship_info.py
@@ -1,0 +1,39 @@
+from src.lib.Event import GameEvent
+from src.lib.projections.ship_info import FighterState, ShipInfo
+
+
+def game_event(content: dict[str, object]) -> GameEvent:
+    return GameEvent(content=content, historic=False)
+
+
+def test_dock_srv_resets_matching_fighter_only() -> None:
+    projection = ShipInfo()
+    projection.state.Fighters = [
+        FighterState(ID=130, Status="Launched", Pilot="Commander"),
+        FighterState(ID=131, Status="Launched", Pilot="NPC Crew"),
+    ]
+
+    projection.process(game_event({
+        "timestamp": "2026-07-12T20:00:41Z",
+        "event": "DockSRV",
+        "SRVType": "lander01",
+        "SRVType_Localised": "Nomad",
+        "ID": 130,
+    }))
+
+    assert projection.state.Fighters[0] == FighterState(Status="Ready")
+    assert projection.state.Fighters[1] == FighterState(
+        ID=131, Status="Launched", Pilot="NPC Crew"
+    )
+
+    projection.process(game_event({
+        "timestamp": "2026-07-12T20:01:52Z",
+        "event": "DockSRV",
+        "SRVType": "lander01",
+        "SRVType_Localised": "Nomad",
+        "ID": 999,
+    }))
+
+    assert projection.state.Fighters[1] == FighterState(
+        ID=131, Status="Launched", Pilot="NPC Crew"
+    )

--- a/test/lib/test_actions_web.py
+++ b/test/lib/test_actions_web.py
@@ -320,6 +320,78 @@ def test_spansh_plot_search_name_disables_fuzzy_matching() -> None:
     }
 
 
+def test_station_request_excludes_carriers_and_includes_planetary_stations_by_default() -> None:
+    request = actions_web.prepare_station_request({}, {})
+
+    assert "Drake-Class Carrier" not in request["filters"]["type"]["value"]
+    assert "is_planetary" not in request["filters"]
+
+
+def test_station_request_includes_carriers_and_excludes_planetary_stations() -> None:
+    request = actions_web.prepare_station_request({
+        "include_player_fleetcarrier": True,
+        "include_planetary_stations": False,
+    }, {})
+
+    assert request["filters"]["type"]["value"][-1] == "Drake-Class Carrier"
+    assert request["filters"]["is_planetary"] == {"value": False}
+
+
+def test_station_request_uses_default_commodity_market_data_age() -> None:
+    request = actions_web.prepare_station_request({
+        "commodities": [{"name": "Tritium", "amount": 100, "transaction": "Buy"}],
+    }, {})
+
+    assert request["filters"]["market_updated_at"] == {
+        "comparison": "<=>",
+        "value": ["now-2d", "now"],
+    }
+
+
+def test_station_request_uses_requested_commodity_market_data_age() -> None:
+    request = actions_web.prepare_station_request({
+        "commodities": [{"name": "Tritium", "amount": 100, "transaction": "Buy"}],
+        "market_days_old": 7,
+    }, {})
+
+    assert request["filters"]["market_updated_at"]["value"] == ["now-7d", "now"]
+
+
+def test_station_request_rejects_invalid_commodity_market_data_age() -> None:
+    try:
+        actions_web.prepare_station_request({
+            "commodities": [{"name": "Tritium", "amount": 100, "transaction": "Buy"}],
+            "market_days_old": 0,
+        }, {})
+    except Exception as error:
+        assert str(error) == "market_days_old must be a positive whole number."
+    else:
+        raise AssertionError("Expected an invalid market data age to be rejected")
+
+
+def test_station_response_reports_effective_commodity_market_data_age() -> None:
+    response = actions_web.filter_station_response({
+        "filters": {
+            "market": [{"name": "Tritium"}],
+            "market_updated_at": {"comparison": "<=>", "value": ["now-7d", "now"]},
+        },
+    }, {
+        "count": 1,
+        "size": 1,
+        "results": [{
+            "name": "Test Station",
+            "system_name": "Sol",
+            "distance": 0,
+            "distance_to_arrival": 10,
+            "is_planetary": False,
+            "services": [],
+            "market": [],
+        }],
+    })
+
+    assert response["market_data_max_age_days"] == 7
+
+
 def test_resolve_plot_target_queries_all_spansh_endpoints(monkeypatch) -> None:
     posted_urls: list[str] = []
 


### PR DESCRIPTION
Adds planetary-station and commodity-market freshness filters to `station_finder`.

- Supports excluding planetary stations.
- Applies configurable market-data age limits, defaulting to two days for commodity searches.
- Reports the effective market-data age in results.
- Documents behavior and adds unit coverage.