### PR TITLE
Fix: handle plugin_settings_button in pre-start loop and fix on_settings_button guid lookup

### DIFF
--- a/src/Chat.py
+++ b/src/Chat.py
@@ -1227,6 +1227,11 @@ if __name__ == "__main__":
                     except Exception as e:
                         log("error", f"Failed to reset quest progress: {e}")
                         emit_message("quest_progress_reset", success=False, message=str(e))
+                if data.get("type") == "plugin_settings_button":
+                    plugin_guid = data.get("plugin_guid")
+                    key = data.get("key")
+                    if isinstance(plugin_guid, str) and isinstance(key, str):
+                        plugin_manager.on_settings_button(plugin_guid, key)        
                 if data.get("type") == "enable_remote_tracing":
                     from lib.Logger import enable_remote_tracing
 

--- a/src/lib/PluginManager.py
+++ b/src/lib/PluginManager.py
@@ -231,7 +231,11 @@ class PluginManager:
 
     def on_settings_button(self, plugin_guid: str, key: str):
         """Route a plugin settings button click to its owning plugin."""
-        plugin = self.plugin_list.get(plugin_guid)
+        plugin = None
+        for p in self.plugin_list.values():
+            if p.plugin_manifest.guid == plugin_guid:
+                plugin = p
+                break
         if plugin is None:
             log('warning', f"Ignoring settings button click for unknown plugin {plugin_guid}")
             return


### PR DESCRIPTION
Two small fixes to improve the plugin button API:

1. `Chat.py` — Added `plugin_settings_button` handler to the pre-start waiting loop. Previously it only existed in `read_stdin` which runs after the assistant starts, making it impossible for plugins to handle button clicks before launch.

2. `PluginManager.py` — Fixed `on_settings_button` to look up plugins by iterating over `plugin_list.values()` and matching by `plugin_manifest.guid`, consistent with how `create_plugin_model` already works. The previous `plugin_list.get(plugin_guid)` lookup always failed silently because plugins are stored under the key `guid.entrypoint_name`.