### PR TITLE
Skip OpenAI validation for plugin providers in model upgrade

### DIFF
--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -1633,6 +1633,11 @@ def check_and_upgrade_model(config: Config) -> ModelValidationResult:
     Returns:
         A ModelValidationResult object containing validation results and messages
     """
+
+    # Skip validation for plugin providers — they handle their own auth
+    if config.get('llm_provider', '').startswith('plugin:'):
+        return {'skipped': True, 'success': True, 'config': None, 'message': None}
+        
     # Make a copy of the config to avoid modifying the original
     updated_config = cast(Config, {k: v for k, v in config.items()})
     


### PR DESCRIPTION
I saw you were looking into this issue, wanted to share how I approached it in case it helps.

**The problem**
When a plugin provider is selected as the LLM provider and no valid OpenAI key is set in the config, `check_and_upgrade_model()` runs on startup and tries to validate the key against OpenAI's endpoint. This happens before the assistant initializes and before the plugin has any chance to authenticate, resulting in a 401 error that prevents the assistant from starting.

This is particularly relevant for plugins that use OAuth or any other flow where the API key is retrieved programmatically rather than entered manually by the user. In those cases, there's no OpenAI key to validate against, and the validation step will always fail.

**The fix**
Added an early return at the start of `check_and_upgrade_model()` when `llm_provider` starts with `plugin:`, skipping the OpenAI validation entirely for plugin providers. Plugin providers handle their own authentication and don't need to be validated against OpenAI's endpoint.

Happy to close this if there's a better approach or if this is something you'd prefer to handle differently.