### PR TITLE
fix: TTS output device selection can silently pick the wrong ALSA device

### DIFF
--- a/src/lib/TTS.py
+++ b/src/lib/TTS.py
@@ -198,15 +198,20 @@ class TTS:
         np.clip(arr, -32768.0, 32767.0, out=arr)
         return arr.astype(np.int16).tobytes()
 
-    def _get_output_device_index(self) -> Optional[int]: #Rewert from String to Index 
+    def _get_output_device_index(self) -> Optional[int]: #Rewert from String to Index
         if not isinstance(self.output_device, str) or not self.output_device:
             return None
+        substring_match: Optional[int] = None
         for i in range(self.p.get_device_count()):
             dev_info = self.p.get_device_info_by_index(i)
             device_name = dev_info.get('name', '')
-            if isinstance(device_name, str) and self.output_device in device_name:
+            if not isinstance(device_name, str):
+                continue
+            if device_name == self.output_device:
                 return i
-        return None
+            if substring_match is None and self.output_device in device_name:
+                substring_match = i
+        return substring_match
 
     def _playback_thread(self):
         backoff = 1


### PR DESCRIPTION
## Summary
- `TTS._get_output_device_index()` matched the configured `output_device_name`
  against PortAudio's device list using a substring (`in`) check and returned
  the first match.
- On Linux, ALSA/PipeWire commonly expose both a `default` and a `sysdefault`
  device. Since `"default" in "sysdefault"` is `True`, and `sysdefault`
  enumerates before `default` on typical desktop setups, users with the very
  common `output_device_name: "default"` config get silently routed to
  `sysdefault` instead — no exception, no log line, just no sound.
- This PR checks for an exact device-name match first, only falling back to
  the old substring match when no exact match exists — so configs that
  intentionally use a partial/prefix device name keep working.

## Why this matters
`default` is the out-of-the-box output device value, so this affects a
default Linux install, not just an edge case. The failure mode is a "TTS
just doesn't play anything, no error anywhere" — very hard for a user to
self-diagnose since it looks like the TTS provider is broken.

## Test plan
- [x] `pytest` — full suite passes
- [x] Reproduced on Fedora/PipeWire: PortAudio enumerates both `sysdefault`
      (index 5) and `default` (index 12); before the fix, `output_device_name:
      "default"` resolved to `sysdefault` and produced no audible output — after
      the fix it resolves to `default` and audio plays correctly.
- [x] Confirmed substring-match fallback still resolves correctly for a
      partial device name.
